### PR TITLE
fix(connection): allow HTTPS connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "kube",
  "kubectl-view-allocations",
  "openssl",
+ "openssl-probe",
  "regex",
  "serde",
  "serde_json",
@@ -1172,6 +1173,12 @@ dependencies = [
  "quote",
  "syn 1.0.99",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [badges]
 
 [dependencies]
+openssl-probe = "0.1.2"
 crossterm = "0.26.1"
 tui = { version = "0.19", default-features = false, features = ['crossterm'] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ pub struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+  openssl_probe::init_ssl_cert_env_vars();
   panic::set_hook(Box::new(|info| {
     panic_hook(info);
   }));


### PR DESCRIPTION
Before my fix, I was unable to connect to HTTPS clusters, I had the following issue : 

```
icasets::KubeReplicaSet. HyperError(hyper::Error(Connect, ConnectError { error: Error { code: ErrorCode(1), cause: Some(Ssl(ErrorStack([Error { code: 337047686, library}
```

Now, it works ;) 