### PR TITLE
fix: web install arch: aarch64

### DIFF
--- a/deployment/getLatest.sh
+++ b/deployment/getLatest.sh
@@ -28,9 +28,7 @@ fail() {
 find_download_url() {
   local SUFFIX=$1
   local LATEST_URL="https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest"
-  local URL=$(curl -s "${LATEST_URL}" | grep "browser_download_url.*${SUFFIX}" | cut -d : -f 2,3 |
-    tr -d \" |
-    head -n 1)
+  local URL=$(curl -s "${LATEST_URL}" | grep "browser_download_url.*${SUFFIX}" | cut -d : -f 2,3 | tr -d \" | head -n 1)
   echo "${URL//[[:space:]]/}"
 }
 
@@ -40,7 +38,8 @@ find_arch() {
   armv5*) ARCH="armv5" ;;
   armv6*) ARCH="armv6" ;;
   armv7*) ARCH="armv7" ;;
-  aarch64) ARCH="arm64" ;;
+  arm64) ARCH="aarch64" ;;
+  aarch64) ARCH="aarch64" ;;
   x86) ARCH="386" ;;
   # x86_64) ARCH="amd64";;
   i686) ARCH="386" ;;
@@ -61,6 +60,7 @@ find_os() {
 }
 
 find_suffix() {
+  local ARCH=$1
   local OS=$2
   local SUFFIX="$OS.tar.gz"
 #   case "$OS" in
@@ -68,6 +68,10 @@ find_suffix() {
 #   "darwin") SUFFIX='macos.tar.gz' ;;
 #   "windows") SUFFIX='windows.tar.gz';;
 #   esac
+  case "$ARCH" in
+  "aarch64") SUFFIX="aarch64-gnu.tar.gz" ;;
+  "arm64") SUFFIX="aarch64-gnu.tar.gz" ;;
+  esac
   echo $SUFFIX
 }
 


### PR DESCRIPTION
Fixing web install arch suffix bug
```
$ curl https://raw.githubusercontent.com/kdash-rs/kdash/main/deployment/getLatest.sh | bash
Getting https://github.com/kdash-rs/kdash/releases/download/v0.4.7/kdash-linux.tar.gz .....
executable installed at /usr/local/bin/kdash
$ kdash
-bash: /usr/local/bin/kdash: cannot execute binary file: Exec format error
$ echo $(uname -m)
aarch64
$ file /usr/local/bin/kdash
/usr/local/bin/kdash: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2 ...
```