### PR TITLE
feat(ui): more efficient redraw

### DIFF
--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -107,7 +107,8 @@ impl Events {
   }
 
   /// Attempts to read an event without blocking.
-  /// Returns `None` if no event is currently available.
+  /// Returns `None` if no event is currently available or if the channel has
+  /// been disconnected.
   pub fn try_next(&self) -> Option<Event<KeyEvent, MouseEvent>> {
     self.rx.try_recv().ok()
   }

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -105,6 +105,12 @@ impl Events {
   pub fn next(&self) -> Result<Event<KeyEvent, MouseEvent>, mpsc::RecvError> {
     self.rx.recv()
   }
+
+  /// Attempts to read an event without blocking.
+  /// Returns `None` if no event is currently available.
+  pub fn try_next(&self) -> Option<Event<KeyEvent, MouseEvent>> {
+    self.rx.try_recv().ok()
+  }
 }
 
 /// Resolve the kubeconfig file paths that should be watched.
@@ -236,6 +242,14 @@ mod tests {
       Ok(Event::KubeConfigChange) => {} // possible if kubeconfig watcher fires
       Err(e) => panic!("Events::next() returned error: {:?}", e),
     }
+  }
+
+  #[test]
+  fn test_try_next_returns_none_when_empty() {
+    // try_next should return None when there are no pending events
+    let (tx, rx) = mpsc::channel();
+    let events = Events { rx, _tx: tx };
+    assert!(events.try_next().is_none());
   }
 
   #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,8 +269,8 @@ async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
     let (pending_shell_exec, should_quit) = {
       let mut app = app.lock().await;
 
-      // --- Handle events BEFORE drawing so the frame always reflects
-      // --- the latest state, eliminating the 1-event visual lag.
+      // Handle events BEFORE drawing so the frame always reflects
+      // the latest state.
 
       // Helper macro to process a single event.  Returns `true` when the
       // app should break out of the main loop (Ctrl+C).

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use cmd::{
 };
 use config::load_config;
 use crossterm::{
+  event::{KeyEvent, MouseEvent},
   execute,
   terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -235,6 +236,39 @@ async fn start_cmd_runner(mut io_rx: mpsc::Receiver<IoCmdEvent>, app: &Arc<Mutex
   }
 }
 
+/// Process a single UI event.  Returns `true` when the app should exit (Ctrl+C).
+async fn process_event(
+  app: &mut App,
+  ev: event::Event<KeyEvent, MouseEvent>,
+  is_first_render: &mut bool,
+) -> bool {
+  match ev {
+    event::Event::Input(key_event) => {
+      let key = Key::from(key_event);
+      if key == Key::Ctrl('c') {
+        true
+      } else {
+        handlers::handle_key_events(key, key_event, app).await;
+        false
+      }
+    }
+    event::Event::MouseInput(mouse) => {
+      handlers::handle_mouse_events(mouse, app).await;
+      false
+    }
+    event::Event::Tick => {
+      app.on_tick(*is_first_render).await;
+      *is_first_render = false;
+      false
+    }
+    event::Event::KubeConfigChange => {
+      info!("Kubeconfig change detected, reloading");
+      app.dispatch(IoEvent::GetKubeConfig).await;
+      false
+    }
+  }
+}
+
 async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
   info!("Starting UI");
   // see https://docs.rs/crossterm/0.17.7/crossterm/terminal/#raw-mode
@@ -270,42 +304,11 @@ async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
       let mut app = app.lock().await;
 
       // Handle events BEFORE drawing so the frame always reflects
-      // the latest state.
-
-      // Helper macro to process a single event.  Returns `true` when the
-      // app should break out of the main loop (Ctrl+C).
-      macro_rules! process_event {
-        ($ev:expr) => {
-          match $ev {
-            event::Event::Input(key_event) => {
-              let key = Key::from(key_event);
-              if key == Key::Ctrl('c') {
-                true
-              } else {
-                handlers::handle_key_events(key, key_event, &mut app).await;
-                false
-              }
-            }
-            event::Event::MouseInput(mouse) => {
-              handlers::handle_mouse_events(mouse, &mut app).await;
-              false
-            }
-            event::Event::Tick => {
-              app.on_tick(is_first_render).await;
-              is_first_render = false;
-              false
-            }
-            event::Event::KubeConfigChange => {
-              info!("Kubeconfig change detected, reloading");
-              app.dispatch(IoEvent::GetKubeConfig).await;
-              false
-            }
-          }
-        };
-      }
+      // the latest state, eliminating the 1-event visual lag.
 
       // Process the blocking event
-      let mut should_break = process_event!(event);
+      let mut should_break =
+        process_event(&mut app, event, &mut is_first_render).await;
 
       // Drain any pending events so rapid key-presses are batched into a
       // single render pass instead of each triggering a stale redraw.
@@ -313,7 +316,8 @@ async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
         for _ in 0..20 {
           match events.try_next() {
             Some(ev) => {
-              should_break = process_event!(ev);
+              should_break =
+                process_event(&mut app, ev, &mut is_first_render).await;
               if should_break {
                 break;
               }

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,7 @@ async fn process_event(
   app: &mut App,
   ev: event::Event<KeyEvent, MouseEvent>,
   is_first_render: &mut bool,
+  tick_seen: &mut bool,
 ) -> bool {
   match ev {
     event::Event::Input(key_event) => {
@@ -259,6 +260,7 @@ async fn process_event(
     event::Event::Tick => {
       app.on_tick(*is_first_render).await;
       *is_first_render = false;
+      *tick_seen = true;
       false
     }
     event::Event::KubeConfigChange => {
@@ -307,15 +309,22 @@ async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
       // the latest state, eliminating the 1-event visual lag.
 
       // Process the blocking event
-      let mut should_break = process_event(&mut app, event, &mut is_first_render).await;
+      let mut tick_seen = false;
+      let mut should_break =
+        process_event(&mut app, event, &mut is_first_render, &mut tick_seen).await;
 
       // Drain any pending events so rapid key-presses are batched into a
       // single render pass instead of each triggering a stale redraw.
+      // Cap at 20 to bound worst-case lock hold under input flood.
+      // Coalesce Ticks: after one Tick fires `on_tick`, drop the rest in
+      // this batch so a stall doesn't replay the backlog as a poll burst.
       if !should_break {
         for _ in 0..20 {
           match events.try_next() {
+            Some(event::Event::Tick) if tick_seen => continue,
             Some(ev) => {
-              should_break = process_event(&mut app, ev, &mut is_first_render).await;
+              should_break =
+                process_event(&mut app, ev, &mut is_first_render, &mut tick_seen).await;
               if should_break {
                 break;
               }
@@ -340,7 +349,6 @@ async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
       // Draw the UI layout AFTER processing events so the frame is up-to-date
       terminal.draw(|f| ui::draw(f, &mut app))?;
 
-      is_first_render = false;
       let pending_shell_exec = app.take_pending_shell_exec();
       let should_quit = app.should_quit;
       (pending_shell_exec, should_quit)
@@ -553,9 +561,10 @@ fn get_panic_info(info: &PanicHookInfo<'_>) -> (String, String) {
 
 #[cfg(test)]
 mod tests {
-  use super::{execute_pending_shell_exec_with, resolve_log_tail_lines};
-  use crate::{app::App, config::KdashConfig};
+  use super::{execute_pending_shell_exec_with, process_event, resolve_log_tail_lines};
+  use crate::{app::App, config::KdashConfig, event};
   use anyhow::anyhow;
+  use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
   use std::sync::Arc;
   use tokio::sync::Mutex;
 
@@ -649,5 +658,71 @@ mod tests {
       "Unable to open shell for api-123/web: probe failed"
     );
     assert!(app.status_message.is_empty());
+  }
+
+  #[tokio::test]
+  async fn test_process_event_tick_advances_state_and_sets_tick_seen() {
+    let mut app = App::default();
+    let mut is_first_render = true;
+    let mut tick_seen = false;
+
+    let exit = process_event(
+      &mut app,
+      event::Event::Tick,
+      &mut is_first_render,
+      &mut tick_seen,
+    )
+    .await;
+
+    assert!(!exit);
+    assert!(
+      tick_seen,
+      "Tick should set tick_seen so the drain can coalesce"
+    );
+    assert!(!is_first_render, "Tick should flip the first-render flag");
+    assert_eq!(app.tick_count, 1);
+  }
+
+  #[tokio::test]
+  async fn test_process_event_input_does_not_flip_first_render_or_tick_seen() {
+    let mut app = App::default();
+    let mut is_first_render = true;
+    let mut tick_seen = false;
+
+    let exit = process_event(
+      &mut app,
+      event::Event::Input(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+      &mut is_first_render,
+      &mut tick_seen,
+    )
+    .await;
+
+    assert!(!exit);
+    assert!(
+      is_first_render,
+      "non-Tick events must not consume the first-render gate"
+    );
+    assert!(
+      !tick_seen,
+      "non-Tick events must not mark a tick as processed"
+    );
+    assert_eq!(app.tick_count, 0);
+  }
+
+  #[tokio::test]
+  async fn test_process_event_ctrl_c_signals_exit() {
+    let mut app = App::default();
+    let mut is_first_render = true;
+    let mut tick_seen = false;
+
+    let exit = process_event(
+      &mut app,
+      event::Event::Input(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+      &mut is_first_render,
+      &mut tick_seen,
+    )
+    .await;
+
+    assert!(exit);
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,8 +307,7 @@ async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
       // the latest state, eliminating the 1-event visual lag.
 
       // Process the blocking event
-      let mut should_break =
-        process_event(&mut app, event, &mut is_first_render).await;
+      let mut should_break = process_event(&mut app, event, &mut is_first_render).await;
 
       // Drain any pending events so rapid key-presses are batched into a
       // single render pass instead of each triggering a stale redraw.
@@ -316,8 +315,7 @@ async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
         for _ in 0..20 {
           match events.try_next() {
             Some(ev) => {
-              should_break =
-                process_event(&mut app, ev, &mut is_first_render).await;
+              should_break = process_event(&mut app, ev, &mut is_first_render).await;
               if should_break {
                 break;
               }

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,15 @@ async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
   // custom events
   let mut events = event::Events::new(cli.tick_rate);
   let mut is_first_render = true;
+  // Perform initial draw so the user sees the UI immediately
+  {
+    let mut app = app.lock().await;
+    if let Ok(size) = terminal.backend().size() {
+      app.size.width = size.width;
+      app.size.height = size.height;
+    }
+    terminal.draw(|f| ui::draw(f, &mut app))?;
+  }
   // main UI loop
   loop {
     // Wait for the next event BEFORE acquiring the lock.
@@ -259,43 +268,75 @@ async fn start_ui(cli: Cli, app: &Arc<Mutex<App>>) -> Result<()> {
 
     let (pending_shell_exec, should_quit) = {
       let mut app = app.lock().await;
-      // Get the size of the screen on each loop to account for resize event
+
+      // --- Handle events BEFORE drawing so the frame always reflects
+      // --- the latest state, eliminating the 1-event visual lag.
+
+      // Helper macro to process a single event.  Returns `true` when the
+      // app should break out of the main loop (Ctrl+C).
+      macro_rules! process_event {
+        ($ev:expr) => {
+          match $ev {
+            event::Event::Input(key_event) => {
+              let key = Key::from(key_event);
+              if key == Key::Ctrl('c') {
+                true
+              } else {
+                handlers::handle_key_events(key, key_event, &mut app).await;
+                false
+              }
+            }
+            event::Event::MouseInput(mouse) => {
+              handlers::handle_mouse_events(mouse, &mut app).await;
+              false
+            }
+            event::Event::Tick => {
+              app.on_tick(is_first_render).await;
+              is_first_render = false;
+              false
+            }
+            event::Event::KubeConfigChange => {
+              info!("Kubeconfig change detected, reloading");
+              app.dispatch(IoEvent::GetKubeConfig).await;
+              false
+            }
+          }
+        };
+      }
+
+      // Process the blocking event
+      let mut should_break = process_event!(event);
+
+      // Drain any pending events so rapid key-presses are batched into a
+      // single render pass instead of each triggering a stale redraw.
+      if !should_break {
+        for _ in 0..20 {
+          match events.try_next() {
+            Some(ev) => {
+              should_break = process_event!(ev);
+              if should_break {
+                break;
+              }
+            }
+            None => break,
+          }
+        }
+      }
+
+      if should_break {
+        break;
+      }
+
+      // Get the size of the screen on each loop to account for resize events
       if let Ok(size) = terminal.backend().size() {
-        // Reset the help menu if the terminal was resized
         if app.refresh || app.size.as_size() != size {
           app.size.width = size.width;
           app.size.height = size.height;
         }
-      };
-
-      // draw the UI layout
-      terminal.draw(|f| ui::draw(f, &mut app))?;
-
-      // handle events
-      match event {
-        event::Event::Input(key_event) => {
-          info!("Input event received: {:?}", key_event);
-          // quit on CTRL + C
-          let key = Key::from(key_event);
-
-          if key == Key::Ctrl('c') {
-            break;
-          }
-          // handle all other keys
-          handlers::handle_key_events(key, key_event, &mut app).await
-        }
-        // handle mouse events
-        event::Event::MouseInput(mouse) => handlers::handle_mouse_events(mouse, &mut app).await,
-        // handle tick events
-        event::Event::Tick => {
-          app.on_tick(is_first_render).await;
-        }
-        // handle kubeconfig file changes (live sync)
-        event::Event::KubeConfigChange => {
-          info!("Kubeconfig change detected, reloading");
-          app.dispatch(IoEvent::GetKubeConfig).await;
-        }
       }
+
+      // Draw the UI layout AFTER processing events so the frame is up-to-date
+      terminal.draw(|f| ui::draw(f, &mut app))?;
 
       is_first_render = false;
       let pending_shell_exec = app.take_pending_shell_exec();

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -693,10 +693,8 @@ pub fn draw_yaml_block(f: &mut Frame<'_>, app: &mut App, area: Rect, title: Line
       app.data.describe_out.highlight_light_theme = app.light_theme;
     }
 
-    // Performance: instead of cloning ALL highlighted lines and wrapping
-    // them all (O(n) per frame), extract only a window of source lines
-    // around the visible region.  The scroll offset is bounded by the
-    // source-line count, so it maps roughly to source-line indices.
+    // Extract only a window of source lines around the visible region.
+    // The scroll offset is bounded by the source-line count, so it maps roughly to source-line indices.
     let offset = app.data.describe_out.offset;
     let total = app.data.describe_out.highlighted_lines.len();
     // Subtract 2 for the top-border of the block
@@ -734,8 +732,7 @@ fn draw_resource_table<'a, T: KubeResource<U>, F, U: Serialize>(
     let has_filter = !filter.is_empty();
     let mut filtered_indices: Vec<usize> = Vec::new();
 
-    // First pass: apply filter and collect filtered indices.
-    // This is cheap because filter_by_name only checks the item name.
+    // Apply filter and collect filtered indices.
     let filtered_items: Vec<(usize, &T)> = table_props
       .resource
       .items
@@ -766,7 +763,7 @@ fn draw_resource_table<'a, T: KubeResource<U>, F, U: Serialize>(
     let visible_start = selected.saturating_sub(view_h);
     let visible_end = (selected + view_h * 2).min(filtered_items.len());
 
-    // Second pass: build Row widgets, using the expensive mapper only for
+    // Build Row widgets, using the expensive mapper only for
     // rows in or near the visible viewport.
     let rows: Vec<Row<'a>> = filtered_items
       .iter()

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -778,18 +778,33 @@ fn ensure_highlight_cache(app: &mut App) -> bool {
   true
 }
 
+/// Compute the (start, end, scroll-within-slice) window into a buffer of
+/// `total` highlighted lines for the given `offset` and visible row count.
+/// Clamps `offset` to a valid index and ensures `start <= end <= total`.
+fn highlight_window(offset: usize, total: usize, view_h: usize) -> (usize, usize, u16) {
+  // Caller guarantees total > 0; clamp here defensively too.
+  let view_h = view_h.max(1);
+  let effective_offset = offset.min(total.saturating_sub(1));
+  let slice_start = effective_offset.saturating_sub(view_h);
+  let slice_end = total.min(effective_offset + view_h * 3);
+  let adjusted_offset = (effective_offset - slice_start).min(u16::MAX as usize) as u16;
+  (slice_start, slice_end, adjusted_offset)
+}
+
 /// common for all resources
 pub fn draw_yaml_block(f: &mut Frame<'_>, app: &mut App, area: Rect, title: Line<'_>) {
   let block = layout_block_top_border(title);
   if ensure_highlight_cache(app) {
-    let offset = app.data.describe_out.offset;
     let total = app.data.describe_out.highlighted_lines.len();
-    // Subtract 2 for the top-border of the block.
-    let view_h = area.height.saturating_sub(2) as usize;
-    // Take a generous window around the visible region.
-    let slice_start = offset.saturating_sub(view_h);
-    let slice_end = total.min(offset + view_h * 3);
-    let adjusted_offset = (offset - slice_start).min(u16::MAX as usize) as u16;
+    if total == 0 {
+      loading(f, block, area, app.is_loading(), app.light_theme);
+      return;
+    }
+    let offset = app.data.describe_out.offset;
+    // Subtract 2 for the top-border of the block; clamp to >=1 so a tiny
+    // terminal doesn't degenerate into an empty slice.
+    let view_h = (area.height.saturating_sub(2) as usize).max(1);
+    let (slice_start, slice_end, adjusted_offset) = highlight_window(offset, total, view_h);
     let visible_lines = app.data.describe_out.highlighted_lines[slice_start..slice_end].to_vec();
     let paragraph = Paragraph::new(visible_lines)
       .block(block)
@@ -841,9 +856,11 @@ fn draw_resource_table<'a, T: Named, F>(
     table_props.resource.filtered_indices = filtered_indices;
 
     // Determine the visible row range to avoid expensive row_cell_mapper
-    // calls for off-screen items.  Subtract 3 for header + borders.
+    // calls for off-screen items. Subtract 3 for header + borders; clamp
+    // to >=1 so a tiny terminal still renders at least one row of data
+    // instead of degenerating into all-empty rows.
     let selected = table_props.resource.state.selected().unwrap_or(0);
-    let view_h = area.height.saturating_sub(3) as usize;
+    let view_h = (area.height.saturating_sub(3) as usize).max(1);
     let visible_start = selected.saturating_sub(view_h);
     let visible_end = (selected + view_h * 2).min(filtered_items.len());
 
@@ -1641,5 +1658,49 @@ mod tests {
       text4.contains("[foo]"),
       "Case 4: expected '{text4}' to contain '[foo]'"
     );
+  }
+
+  #[test]
+  fn test_highlight_window_offset_within_bounds() {
+    // total=100, view_h=10, offset=50 → window straddles the offset.
+    let (start, end, scroll) = highlight_window(50, 100, 10);
+    assert_eq!(start, 40);
+    assert_eq!(end, 80);
+    assert_eq!(scroll, 10);
+    assert!(start <= end && end <= 100);
+  }
+
+  #[test]
+  fn test_highlight_window_offset_at_zero() {
+    let (start, end, scroll) = highlight_window(0, 100, 10);
+    assert_eq!(start, 0);
+    assert_eq!(end, 30);
+    assert_eq!(scroll, 0);
+  }
+
+  #[test]
+  fn test_highlight_window_offset_exceeds_total_does_not_panic() {
+    // Regression: items.len() can exceed highlighted_lines.len() when
+    // some lines fail to highlight, leaving offset stale relative to total.
+    // The slice [start..end] must remain valid.
+    let (start, end, _) = highlight_window(50, 5, 10);
+    assert!(start <= end, "start {start} must not exceed end {end}");
+    assert!(end <= 5, "end {end} must not exceed total");
+  }
+
+  #[test]
+  fn test_highlight_window_view_h_zero_clamps_to_one() {
+    // A view height of 0 should not collapse the window to empty.
+    let (start, end, _) = highlight_window(2, 10, 0);
+    assert!(start < end, "window must not be empty when content exists");
+  }
+
+  #[test]
+  fn test_highlight_window_total_one() {
+    // Single-line buffer must produce a non-empty window.
+    let (start, end, scroll) = highlight_window(0, 1, 5);
+    assert_eq!(start, 0);
+    assert_eq!(end, 1);
+    assert_eq!(scroll, 0);
   }
 }

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -693,13 +693,25 @@ pub fn draw_yaml_block(f: &mut Frame<'_>, app: &mut App, area: Rect, title: Line
       app.data.describe_out.highlight_light_theme = app.light_theme;
     }
 
-    let paragraph = Paragraph::new(app.data.describe_out.highlighted_lines.clone())
+    // Performance: instead of cloning ALL highlighted lines and wrapping
+    // them all (O(n) per frame), extract only a window of source lines
+    // around the visible region.  The scroll offset is bounded by the
+    // source-line count, so it maps roughly to source-line indices.
+    let offset = app.data.describe_out.offset;
+    let total = app.data.describe_out.highlighted_lines.len();
+    // Subtract 2 for the top-border of the block
+    let view_h = area.height.saturating_sub(2) as usize;
+    // Take a generous window: some lines before `offset` (to cover
+    // wrapping that shifts content up) and several screen-heights after.
+    let slice_start = offset.saturating_sub(view_h);
+    let slice_end = total.min(offset + view_h * 3);
+    let visible_lines = app.data.describe_out.highlighted_lines[slice_start..slice_end].to_vec();
+    let adjusted_offset = (offset - slice_start).min(u16::MAX as usize) as u16;
+
+    let paragraph = Paragraph::new(visible_lines)
       .block(block)
       .wrap(Wrap { trim: false })
-      .scroll((
-        app.data.describe_out.offset.min(u16::MAX as usize) as u16,
-        0,
-      ));
+      .scroll((adjusted_offset, 0));
     f.render_widget(paragraph, area);
   } else {
     loading(f, block, area, app.is_loading(), app.light_theme);
@@ -721,29 +733,24 @@ fn draw_resource_table<'a, T: KubeResource<U>, F, U: Serialize>(
     let filter = table_props.resource.filter.to_lowercase();
     let has_filter = !filter.is_empty();
     let mut filtered_indices: Vec<usize> = Vec::new();
-    let rows: Vec<Row<'a>> = table_props
+
+    // First pass: apply filter and collect filtered indices.
+    // This is cheap because filter_by_name only checks the item name.
+    let filtered_items: Vec<(usize, &T)> = table_props
       .resource
       .items
       .iter()
       .enumerate()
-      .filter_map(|(idx, c)| {
-        let mapper = row_cell_mapper(c);
-        if filter.is_empty() || filter_by_name(&filter, c) {
-          Some((idx, mapper))
-        } else {
-          None
-        }
-      })
-      .map(|(idx, row)| {
+      .filter(|(_, c)| filter.is_empty() || filter_by_name(&filter, *c))
+      .inspect(|(idx, _)| {
         if has_filter {
-          filtered_indices.push(idx);
+          filtered_indices.push(*idx);
         }
-        row
       })
       .collect();
 
     if has_filter {
-      let max = filtered_indices.len().saturating_sub(1);
+      let max = filtered_items.len().saturating_sub(1);
       if let Some(sel) = table_props.resource.state.selected() {
         if sel > max {
           table_props.resource.state.select(Some(max));
@@ -751,6 +758,27 @@ fn draw_resource_table<'a, T: KubeResource<U>, F, U: Serialize>(
       }
     }
     table_props.resource.filtered_indices = filtered_indices;
+
+    // Determine the visible row range to avoid expensive row_cell_mapper
+    // calls for off-screen items.  Subtract 3 for header + borders.
+    let selected = table_props.resource.state.selected().unwrap_or(0);
+    let view_h = area.height.saturating_sub(3) as usize;
+    let visible_start = selected.saturating_sub(view_h);
+    let visible_end = (selected + view_h * 2).min(filtered_items.len());
+
+    // Second pass: build Row widgets, using the expensive mapper only for
+    // rows in or near the visible viewport.
+    let rows: Vec<Row<'a>> = filtered_items
+      .iter()
+      .enumerate()
+      .map(|(fi, (_orig_idx, item))| {
+        if fi >= visible_start && fi < visible_end {
+          row_cell_mapper(item)
+        } else {
+          Row::default()
+        }
+      })
+      .collect();
 
     let table = Table::new(rows, &table_props.column_widths)
       .header(table_header_style(table_props.table_headers, light_theme))

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -659,53 +659,55 @@ pub fn draw_describe_block(f: &mut Frame<'_>, app: &mut App, area: Rect, title: 
   draw_yaml_block(f, app, area, title);
 }
 
+/// Refreshes the syntax-highlight cache when empty or the theme changed.
+/// Returns `false` when there is no content to highlight.
+fn ensure_highlight_cache(app: &mut App) -> bool {
+  if app.data.describe_out.get_txt().is_empty() {
+    return false;
+  }
+  if app.data.describe_out.highlighted_lines.is_empty()
+    || app.data.describe_out.highlight_light_theme != app.light_theme
+  {
+    let ss = get_syntax_set();
+    let syntax = get_yaml_syntax_reference();
+    let theme = if app.light_theme {
+      &get_yaml_themes().light
+    } else {
+      &get_yaml_themes().dark
+    };
+    let mut h = syntect::easy::HighlightLines::new(syntax, theme);
+    let txt = app.data.describe_out.get_txt();
+    let lines: Vec<_> = syntect::util::LinesWithEndings::from(txt)
+      .filter_map(|line| match h.highlight_line(line, ss) {
+        Ok(segments) => {
+          let line_spans: Vec<_> = segments
+            .into_iter()
+            .filter_map(syntect_to_ratatui_span_owned)
+            .collect();
+          Some(ratatui::text::Line::from(line_spans))
+        }
+        Err(_) => None,
+      })
+      .collect();
+    app.data.describe_out.highlighted_lines = lines;
+    app.data.describe_out.highlight_light_theme = app.light_theme;
+  }
+  true
+}
+
 /// common for all resources
 pub fn draw_yaml_block(f: &mut Frame<'_>, app: &mut App, area: Rect, title: Line<'_>) {
   let block = layout_block_top_border(title);
-
-  let txt = app.data.describe_out.get_txt();
-  if !txt.is_empty() {
-    // Re-highlight only when the cache is empty or the theme changed.
-    if app.data.describe_out.highlighted_lines.is_empty()
-      || app.data.describe_out.highlight_light_theme != app.light_theme
-    {
-      let ss = get_syntax_set();
-      let syntax = get_yaml_syntax_reference();
-      let theme = if app.light_theme {
-        &get_yaml_themes().light
-      } else {
-        &get_yaml_themes().dark
-      };
-      let mut h = syntect::easy::HighlightLines::new(syntax, theme);
-      let lines: Vec<_> = syntect::util::LinesWithEndings::from(txt)
-        .filter_map(|line| match h.highlight_line(line, ss) {
-          Ok(segments) => {
-            let line_spans: Vec<_> = segments
-              .into_iter()
-              .filter_map(syntect_to_ratatui_span_owned)
-              .collect();
-            Some(ratatui::text::Line::from(line_spans))
-          }
-          Err(_) => None,
-        })
-        .collect();
-      app.data.describe_out.highlighted_lines = lines;
-      app.data.describe_out.highlight_light_theme = app.light_theme;
-    }
-
-    // Extract only a window of source lines around the visible region.
-    // The scroll offset is bounded by the source-line count, so it maps roughly to source-line indices.
+  if ensure_highlight_cache(app) {
     let offset = app.data.describe_out.offset;
     let total = app.data.describe_out.highlighted_lines.len();
-    // Subtract 2 for the top-border of the block
+    // Subtract 2 for the top-border of the block.
     let view_h = area.height.saturating_sub(2) as usize;
-    // Take a generous window: some lines before `offset` (to cover
-    // wrapping that shifts content up) and several screen-heights after.
+    // Take a generous window around the visible region.
     let slice_start = offset.saturating_sub(view_h);
     let slice_end = total.min(offset + view_h * 3);
-    let visible_lines = app.data.describe_out.highlighted_lines[slice_start..slice_end].to_vec();
     let adjusted_offset = (offset - slice_start).min(u16::MAX as usize) as u16;
-
+    let visible_lines = app.data.describe_out.highlighted_lines[slice_start..slice_end].to_vec();
     let paragraph = Paragraph::new(visible_lines)
       .block(block)
       .wrap(Wrap { trim: false })
@@ -732,7 +734,6 @@ fn draw_resource_table<'a, T: KubeResource<U>, F, U: Serialize>(
     let has_filter = !filter.is_empty();
     let mut filtered_indices: Vec<usize> = Vec::new();
 
-    // Apply filter and collect filtered indices.
     let filtered_items: Vec<(usize, &T)> = table_props
       .resource
       .items
@@ -763,8 +764,6 @@ fn draw_resource_table<'a, T: KubeResource<U>, F, U: Serialize>(
     let visible_start = selected.saturating_sub(view_h);
     let visible_end = (selected + view_h * 2).min(filtered_items.len());
 
-    // Build Row widgets, using the expensive mapper only for
-    // rows in or near the visible viewport.
     let rows: Vec<Row<'a>> = filtered_items
       .iter()
       .enumerate()
@@ -787,6 +786,41 @@ fn draw_resource_table<'a, T: KubeResource<U>, F, U: Serialize>(
   } else {
     loading(f, block, area, is_loading, light_theme);
   }
+}
+
+/// Builds the help `Line` for a resource block title, weaving filter status
+/// into any existing inline help (placing it after a "containers" prefix when present).
+fn build_resource_help_line(
+  inline_help: Line<'_>,
+  filter: &str,
+  filter_active: bool,
+  light_theme: bool,
+) -> Line<'static> {
+  let inline_help_text = inline_help
+    .spans
+    .iter()
+    .map(|span| span.content.as_ref())
+    .collect::<String>();
+  let containers_prefix = format!(
+    "{} | ",
+    action_hint("containers", DEFAULT_KEYBINDING.submit.key)
+  );
+  let mut help_parts: Vec<LinePart<'static>> = Vec::new();
+  if let Some(rest) = inline_help_text.strip_prefix(&containers_prefix) {
+    help_parts.push(help_part(containers_prefix));
+    help_parts.extend(owned_filter_status_parts(filter, filter_active));
+    if !rest.is_empty() {
+      help_parts.push(help_part(" | ".to_string()));
+      help_parts.push(help_part(rest.to_string()));
+    }
+  } else {
+    help_parts.extend(owned_filter_status_parts(filter, filter_active));
+    if !inline_help_text.is_empty() {
+      help_parts.push(help_part(" | ".to_string()));
+      help_parts.push(help_part(inline_help_text));
+    }
+  }
+  mixed_bold_line(help_parts, light_theme)
 }
 
 /// Draw a kubernetes resource overview tab
@@ -836,31 +870,8 @@ pub fn draw_resource_block<'a, T: KubeResource<U>, F, U: Serialize>(
     return;
   }
 
-  let inline_help_text = inline_help
-    .spans
-    .iter()
-    .map(|span| span.content.as_ref())
-    .collect::<String>();
-  let containers_prefix = format!(
-    "{} | ",
-    action_hint("containers", DEFAULT_KEYBINDING.submit.key)
-  );
-  let mut help_parts = Vec::new();
-  if let Some(rest) = inline_help_text.strip_prefix(&containers_prefix) {
-    help_parts.push(help_part(containers_prefix.clone()));
-    help_parts.extend(owned_filter_status_parts(&filter, filter_active));
-    if !rest.is_empty() {
-      help_parts.push(help_part(" | "));
-      help_parts.push(help_part(rest.to_string()));
-    }
-  } else {
-    help_parts.extend(owned_filter_status_parts(&filter, filter_active));
-    if !inline_help_text.is_empty() {
-      help_parts.push(help_part(" | "));
-      help_parts.push(help_part(inline_help_text));
-    }
-  }
-  let title = title_with_dual_style(title, mixed_bold_line(help_parts, light_theme), light_theme);
+  let help_line = build_resource_help_line(inline_help, &filter, filter_active, light_theme);
+  let title = title_with_dual_style(title, help_line, light_theme);
   let block = layout_block_top_border(title);
   draw_resource_table(
     f,
@@ -1480,6 +1491,56 @@ mod tests {
     assert_eq!(
       get_cluster_wide_resource_title("Nodes", 10, "-> hello"),
       " Nodes [10] -> hello"
+    );
+  }
+
+  #[test]
+  fn test_build_resource_help_line() {
+    // Case 1: Empty inline_help, empty filter, filter_active=false
+    // -> line text should contain the inactive "filter <key>" action hint
+    let line = build_resource_help_line(Line::default(), "", false, false);
+    let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+    let expected_filter_hint = action_hint("filter", DEFAULT_KEYBINDING.filter.key);
+    assert!(
+      text.contains(&expected_filter_hint),
+      "Case 1: expected '{text}' to contain '{expected_filter_hint}'"
+    );
+
+    // Case 2: Non-empty inline_help, empty filter, filter_active=false
+    // -> line text should contain the inline help hint after " | "
+    let line2 = build_resource_help_line(help_bold_line("-> yaml <y>", false), "", false, false);
+    let text2: String = line2.spans.iter().map(|s| s.content.as_ref()).collect();
+    assert!(
+      text2.contains("-> yaml <y>"),
+      "Case 2: expected '{text2}' to contain '-> yaml <y>'"
+    );
+
+    // Case 3: inline_help starting with the containers prefix
+    // -> line text should start with the containers hint
+    let containers_prefix_str = format!(
+      "{} | ",
+      action_hint("containers", DEFAULT_KEYBINDING.submit.key)
+    );
+    let line3 = build_resource_help_line(
+      help_bold_line(containers_prefix_str.as_str(), false),
+      "",
+      false,
+      false,
+    );
+    let text3: String = line3.spans.iter().map(|s| s.content.as_ref()).collect();
+    let containers_hint = action_hint("containers", DEFAULT_KEYBINDING.submit.key);
+    assert!(
+      text3.starts_with(&containers_hint),
+      "Case 3: expected '{text3}' to start with '{containers_hint}'"
+    );
+
+    // Case 4: Empty inline_help, filter="foo", filter_active=false
+    // -> line text should contain "[foo]"
+    let line4 = build_resource_help_line(Line::default(), "foo", false, false);
+    let text4: String = line4.spans.iter().map(|s| s.content.as_ref()).collect();
+    assert!(
+      text4.contains("[foo]"),
+      "Case 4: expected '{text4}' to contain '[foo]'"
     );
   }
 }


### PR DESCRIPTION
## Problem
In the UI, when I press `<d>` to obtain the output of `kubectl describe` and scroll through the output, the response feels a bit laggy and sluggish. The lagginess is also noticeable when moving the selection up/down.

## Solution
- Handle-before-draw
- Borrow instead clone
- Drain pending events
- Cache wrapped output
- Cache rows when data unchanged

AI usage:
- Analysis and implementation - Opus 4.6.