### PR TITLE
Better scrolling

### DIFF
--- a/src/app/key_binding.rs
+++ b/src/app/key_binding.rs
@@ -67,6 +67,8 @@ generate_keybindings! {
   dump_error_log,
   pg_up,
   pg_down,
+  home,
+  end,
   up,
   down,
   left,
@@ -227,6 +229,18 @@ const DEFAULT_KEYBINDINGS: KeyBindings = KeyBindings {
     key: Key::PageDown,
     alt: None,
     desc: "Scroll page down",
+    context: HContext::General,
+  },
+  home: KeyBinding {
+    key: Key::Home,
+    alt: None,
+    desc: "Scroll to top",
+    context: HContext::General,
+  },
+  end: KeyBinding {
+    key: Key::End,
+    alt: None,
+    desc: "Scroll to bottom",
     context: HContext::General,
   },
   left: KeyBinding {

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -87,7 +87,9 @@ pub trait Scrollable {
   /// calculates the new position after applying wrapping logic (modulo)
   fn wrap(&self, event: &ScrollEvent, current_pos: Option<usize>) -> usize {
     let len = self.length() as isize;
-    (self.newpos(event, current_pos) % len) as usize
+    // rem_euclid returns a non-negative result for negative inputs, e.g. -1 rem_euclid 5 = 4,
+    // so it correctly wraps around to the end when scrolling up from the top
+    (self.newpos(event, current_pos).rem_euclid(len)) as usize
   }
 }
 
@@ -127,7 +129,7 @@ impl<T> Scrollable for StatefulList<T> {
 
   // for lists we cycle back to the beginning when we reach the end
   fn wraps(&self) -> bool {
-    false
+    true
   }
 }
 

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -87,6 +87,9 @@ pub trait Scrollable {
   /// calculates the new position after applying wrapping logic (modulo)
   fn wrap(&self, event: &ScrollEvent, current_pos: Option<usize>) -> usize {
     let len = self.length() as isize;
+    if len == 0 {
+      return 0;
+    }
     // rem_euclid returns a non-negative result for negative inputs, e.g. -1 rem_euclid 5 = 4,
     // so it correctly wraps around to the end when scrolling up from the top
     (self.newpos(event, current_pos).rem_euclid(len)) as usize

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -81,6 +81,7 @@ pub trait Scrollable {
         let curpos = current_pos.unwrap_or(0) as isize;
         curpos + delta
       }
+      ScrollEvent::End => self.length() as isize - 1,
     }
   }
   /// calculates the new position after applying wrapping logic (modulo)

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -11,7 +11,7 @@ use ratatui::{
 use serde::Serialize;
 
 use super::{ActiveBlock, App, Route};
-use crate::network::Network;
+use crate::{handlers::ScrollEvent, network::Network};
 
 #[async_trait]
 pub trait AppResource {
@@ -54,17 +54,40 @@ pub trait KubeResource<T: Serialize>: Named {
 }
 
 pub trait Scrollable {
-  fn handle_scroll(&mut self, up: bool, page: bool) {
-    // support page up/down
-    let inc_or_dec = if page { 10 } else { 1 };
-    if up {
-      self.scroll_up(inc_or_dec);
+  // To be implemented by structs
+  fn scroll_to(&mut self, index: usize);
+  fn current_pos(&self) -> Option<usize>;
+  fn length(&self) -> usize;
+  /// Whether the scroll should wrap around when reaching the end (true) or clamp (false).
+  fn wraps(&self) -> bool;
+
+  fn handle_scroll(&mut self, event: ScrollEvent) {
+    self.scroll_to(if self.wraps() {
+      self.wrap(&event, self.current_pos())
     } else {
-      self.scroll_down(inc_or_dec);
+      let newpos = self.newpos(&event, self.current_pos());
+      if newpos < 0 {
+        0
+      } else {
+        (newpos as usize).min(self.length().saturating_sub(1))
+      }
+    });
+  }
+  /// calculates the raw new position after applying a scroll event
+  fn newpos(&self, event: &ScrollEvent, current_pos: Option<usize>) -> isize {
+    match event {
+      ScrollEvent::Absolute(newpos) => *newpos,
+      ScrollEvent::Relative(delta) => {
+        let curpos = current_pos.unwrap_or(0) as isize;
+        curpos + delta
+      }
     }
   }
-  fn scroll_down(&mut self, inc_or_dec: usize);
-  fn scroll_up(&mut self, inc_or_dec: usize);
+  /// calculates the new position after applying wrapping logic (modulo)
+  fn wrap(&self, event: &ScrollEvent, current_pos: Option<usize>) -> usize {
+    let len = self.length() as isize;
+    (self.newpos(event, current_pos) % len) as usize
+  }
 }
 
 pub struct StatefulList<T> {
@@ -89,33 +112,21 @@ impl<T> StatefulList<T> {
 }
 
 impl<T> Scrollable for StatefulList<T> {
-  // for lists we cycle back to the beginning when we reach the end
-  fn scroll_down(&mut self, increment: usize) {
-    let i = match self.state.selected() {
-      Some(i) => {
-        if i >= self.items.len().saturating_sub(increment) {
-          0
-        } else {
-          i + increment
-        }
-      }
-      None => 0,
-    };
-    self.state.select(Some(i));
+  fn current_pos(&self) -> Option<usize> {
+    self.state.selected()
   }
-  // for lists we cycle back to the end when we reach the beginning
-  fn scroll_up(&mut self, decrement: usize) {
-    let i = match self.state.selected() {
-      Some(i) => {
-        if i == 0 {
-          self.items.len().saturating_sub(decrement)
-        } else {
-          i.saturating_sub(decrement)
-        }
-      }
-      None => 0,
-    };
-    self.state.select(Some(i));
+
+  fn length(&self) -> usize {
+    self.items.len()
+  }
+
+  fn scroll_to(&mut self, index: usize) {
+    self.state.select(Some(index));
+  }
+
+  // for lists we cycle back to the beginning when we reach the end
+  fn wraps(&self) -> bool {
+    false
   }
 }
 
@@ -193,22 +204,21 @@ impl<T> FilterableTable for StatefulTable<T> {
 }
 
 impl<T> Scrollable for StatefulTable<T> {
-  fn scroll_down(&mut self, increment: usize) {
-    if let Some(i) = self.state.selected() {
-      if (i + increment) < self.items.len() {
-        self.state.select(Some(i + increment));
-      } else {
-        self.state.select(Some(self.items.len().saturating_sub(1)));
-      }
+  fn current_pos(&self) -> Option<usize> {
+    self.state.selected()
+  }
+  fn length(&self) -> usize {
+    if self.filter_active {
+      self.filtered_indices.len()
+    } else {
+      self.items.len()
     }
   }
-
-  fn scroll_up(&mut self, decrement: usize) {
-    if let Some(i) = self.state.selected() {
-      if i != 0 {
-        self.state.select(Some(i.saturating_sub(decrement)));
-      }
-    }
+  fn scroll_to(&mut self, index: usize) {
+    self.state.select(Some(index));
+  }
+  fn wraps(&self) -> bool {
+    false
   }
 }
 
@@ -324,20 +334,17 @@ impl ScrollableTxt {
 }
 
 impl Scrollable for ScrollableTxt {
-  fn scroll_down(&mut self, increment: usize) {
-    // Ratatui's Paragraph with Wrap counts scroll offset in *visual* rows
-    // (post-wrap), but we only know the number of source lines.  We cap at
-    // items.len() - 1 so at least the last source line remains visible,
-    // while still allowing enough scroll range for wrapped content.
-    let max_offset = self.items.len().saturating_sub(1);
-    if self.offset < max_offset {
-      self.offset = (self.offset + increment).min(max_offset);
-    }
+  fn current_pos(&self) -> Option<usize> {
+    self.offset.into()
   }
-  fn scroll_up(&mut self, decrement: usize) {
-    if self.offset > 0 {
-      self.offset = self.offset.saturating_sub(decrement);
-    }
+  fn length(&self) -> usize {
+    self.items.len()
+  }
+  fn scroll_to(&mut self, index: usize) {
+    self.offset = index.min(self.items.len().saturating_sub(1));
+  }
+  fn wraps(&self) -> bool {
+    false
   }
 }
 
@@ -483,26 +490,17 @@ impl LogsState {
 }
 
 impl Scrollable for LogsState {
-  fn scroll_down(&mut self, increment: usize) {
-    let i = self.state.selected().map_or(0, |i| {
-      if i >= self.wrapped_length.saturating_sub(increment) {
-        i
-      } else {
-        i + increment
-      }
-    });
-    self.state.select(Some(i));
+  fn current_pos(&self) -> Option<usize> {
+    self.state.selected()
   }
-
-  fn scroll_up(&mut self, decrement: usize) {
-    let i = self.state.selected().map_or(0, |i| {
-      if i != 0 {
-        i.saturating_sub(decrement)
-      } else {
-        0
-      }
-    });
-    self.state.select(Some(i));
+  fn length(&self) -> usize {
+    self.wrapped_length
+  }
+  fn scroll_to(&mut self, index: usize) {
+    self.state.select(Some(index));
+  }
+  fn wraps(&self) -> bool {
+    false
   }
 }
 
@@ -577,18 +575,18 @@ mod tests {
     // check scroll down
     sft.state.select(Some(0));
     assert_eq!(sft.state.selected(), Some(0));
-    sft.scroll_down(1);
+    sft.handle_scroll(ScrollEvent::down());
     assert_eq!(sft.state.selected(), Some(1));
     // check scroll overflow
-    sft.scroll_down(1);
+    sft.handle_scroll(ScrollEvent::down());
     assert_eq!(sft.state.selected(), Some(1));
-    sft.scroll_up(1);
+    sft.handle_scroll(ScrollEvent::up());
     assert_eq!(sft.state.selected(), Some(0));
     // check scroll overflow
-    sft.scroll_up(1);
+    sft.handle_scroll(ScrollEvent::up());
     assert_eq!(sft.state.selected(), Some(0));
     // check increment
-    sft.scroll_down(10);
+    sft.handle_scroll(ScrollEvent::Relative(10));
     assert_eq!(sft.state.selected(), Some(1));
 
     let sft2 = StatefulTable::with_items(vec![KubeNs::default(), KubeNs::default()]);
@@ -652,22 +650,22 @@ mod tests {
 
     assert_eq!(item.state.selected(), Some(0));
 
-    item.handle_scroll(false, false);
+    item.handle_scroll(ScrollEvent::down());
     assert_eq!(item.state.selected(), Some(1));
 
-    item.handle_scroll(false, false);
+    item.handle_scroll(ScrollEvent::down());
     assert_eq!(item.state.selected(), Some(2));
 
-    item.handle_scroll(false, false);
+    item.handle_scroll(ScrollEvent::down());
     assert_eq!(item.state.selected(), Some(2));
     // previous
-    item.handle_scroll(true, false);
+    item.handle_scroll(ScrollEvent::up());
     assert_eq!(item.state.selected(), Some(1));
     // page down
-    item.handle_scroll(false, true);
+    item.handle_scroll(ScrollEvent::Relative(10));
     assert_eq!(item.state.selected(), Some(2));
     // page up
-    item.handle_scroll(true, true);
+    item.handle_scroll(ScrollEvent::Relative(-10));
     assert_eq!(item.state.selected(), Some(0));
   }
 
@@ -717,30 +715,30 @@ mod tests {
     assert_eq!(stxt.get_txt(), "test\n multiline\n string");
 
     // 3 items → max offset = 2 (last line visible)
-    stxt.scroll_down(1);
+    stxt.handle_scroll(ScrollEvent::down());
     assert_eq!(stxt.offset, 1);
-    stxt.scroll_down(5);
+    stxt.handle_scroll(ScrollEvent::Relative(5));
     assert_eq!(stxt.offset, 2);
 
     // 10 lines → max offset = 9
     let mut stxt2 = ScrollableTxt::with_string("te\nst\nmul\ntil\ni\nne\nstr\ni\nn\ng".into());
     assert_eq!(stxt2.items.len(), 10);
-    stxt2.scroll_down(1);
+    stxt2.handle_scroll(ScrollEvent::down());
     assert_eq!(stxt2.offset, 1);
-    stxt2.scroll_down(1);
+    stxt2.handle_scroll(ScrollEvent::down());
     assert_eq!(stxt2.offset, 2);
-    stxt2.scroll_down(5);
+    stxt2.handle_scroll(ScrollEvent::Relative(5));
     assert_eq!(stxt2.offset, 7);
     for _ in 0..5 {
-      stxt2.scroll_down(1);
+      stxt2.handle_scroll(ScrollEvent::down());
     }
     // capped at len - 1 = 9
     assert_eq!(stxt2.offset, 9);
-    stxt2.scroll_up(1);
+    stxt2.handle_scroll(ScrollEvent::up());
     assert_eq!(stxt2.offset, 8);
-    stxt2.scroll_up(8);
+    stxt2.handle_scroll(ScrollEvent::Relative(-8));
     assert_eq!(stxt2.offset, 0);
-    stxt2.scroll_up(1);
+    stxt2.handle_scroll(ScrollEvent::up());
     // no overflow past (0)
     assert_eq!(stxt2.offset, 0);
   }
@@ -753,7 +751,7 @@ mod tests {
 
     assert_eq!(stxt.items.len(), 100);
     for _ in 0..110 {
-      stxt.scroll_down(1);
+      stxt.handle_scroll(ScrollEvent::down());
     }
     assert_eq!(stxt.offset, 99);
   }
@@ -763,7 +761,7 @@ mod tests {
     // 1 line → max offset = 0
     let mut stxt = ScrollableTxt::with_string("hello".into());
 
-    stxt.scroll_down(1);
+    stxt.handle_scroll(ScrollEvent::down());
     assert_eq!(stxt.offset, 0);
   }
 
@@ -774,7 +772,7 @@ mod tests {
     let mut stxt = ScrollableTxt::with_string(lines.join("\n"));
 
     for _ in 0..30 {
-      stxt.scroll_down(1);
+      stxt.handle_scroll(ScrollEvent::down());
     }
     assert_eq!(stxt.offset, 19);
   }
@@ -790,11 +788,11 @@ mod tests {
     // Scroll down past u16::MAX in large steps — should not wrap or panic
     let target = line_count.saturating_sub(1); // max reachable offset (len - 1)
     for _ in 0..(target / 1000) {
-      stxt.scroll_down(1000);
+      stxt.handle_scroll(ScrollEvent::Relative(1000));
     }
     // Finish off with single increments to reach the cap
     for _ in 0..1000 {
-      stxt.scroll_down(1);
+      stxt.handle_scroll(ScrollEvent::down());
     }
 
     // Offset must be beyond what u16 could hold and must not have wrapped
@@ -813,10 +811,10 @@ mod tests {
 
     // Scroll back up past u16::MAX boundary — should not wrap or panic
     for _ in 0..(stxt.offset / 1000) {
-      stxt.scroll_up(1000);
+      stxt.handle_scroll(ScrollEvent::Relative(-1000));
     }
     for _ in 0..1000 {
-      stxt.scroll_up(1);
+      stxt.handle_scroll(ScrollEvent::up());
     }
     assert_eq!(stxt.offset, 0);
   }
@@ -828,7 +826,7 @@ mod tests {
     let mut stxt = ScrollableTxt::with_string(lines.join("\n"));
 
     for _ in 0..20 {
-      stxt.scroll_down(1);
+      stxt.handle_scroll(ScrollEvent::down());
     }
     assert_eq!(stxt.offset, 9);
   }
@@ -918,8 +916,8 @@ mod tests {
 
     terminal.backend().assert_buffer(&expected4);
 
-    log.scroll_up(1); // to reset select state
-    log.scroll_down(11);
+    log.handle_scroll(ScrollEvent::up()); // to reset select state
+    log.handle_scroll(ScrollEvent::Relative(11));
 
     terminal
       .draw(|f| log.render_list(f, f.area(), Block::default(), Style::default(), false))

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -108,13 +108,13 @@ macro_rules! handle_resource_action {
 /// Dispatches scroll for standard resource types.
 /// Wraps the entire match expression. Special-case arms go in the `extra` block.
 macro_rules! handle_resource_scroll {
-  ($match_expr:expr, $app:expr, $up:expr, $page:expr,
+  ($match_expr:expr, $app:expr, $event:expr, $is_mouse:expr,
     [ $(($block:path, $field:ident)),* $(,)? ],
     extra: { $($extra_arms:tt)* }
   ) => {
     match $match_expr {
       $(
-        $block => $app.data.$field.handle_scroll($up, $page),
+        $block => $app.data.$field.handle_scroll($event),
       )*
       $($extra_arms)*
     }
@@ -171,19 +171,19 @@ pub async fn handle_key_events(key: Key, key_event: KeyEvent, app: &mut App) {
         || key == DEFAULT_KEYBINDING.up.alt.unwrap()
         || key == Key::Up =>
       {
-        handle_block_scroll(app, true, false, false).await;
+        handle_block_scroll(app, ScrollEvent::up(), false).await;
       }
       _ if key == DEFAULT_KEYBINDING.down.key
         || key == DEFAULT_KEYBINDING.down.alt.unwrap()
         || key == Key::Down =>
       {
-        handle_block_scroll(app, false, false, false).await;
+        handle_block_scroll(app, ScrollEvent::down(), false).await;
       }
       _ if key == DEFAULT_KEYBINDING.pg_up.key => {
-        handle_block_scroll(app, true, false, true).await;
+        handle_block_scroll(app, ScrollEvent::Relative(-10), false).await;
       }
       _ if key == DEFAULT_KEYBINDING.pg_down.key => {
-        handle_block_scroll(app, false, false, true).await;
+        handle_block_scroll(app, ScrollEvent::Relative(10), false).await;
       }
       _ if key == DEFAULT_KEYBINDING.toggle_theme.key => {
         app.light_theme = !app.light_theme;
@@ -499,7 +499,7 @@ async fn handle_action_menu_key(key: Key, app: &mut App) {
       || key == Key::Up =>
     {
       if let Some(menu) = app.action_menu.as_mut() {
-        menu.handle_scroll(true, false);
+        menu.handle_scroll(ScrollEvent::up());
       }
     }
     _ if key == DEFAULT_KEYBINDING.down.key
@@ -507,7 +507,7 @@ async fn handle_action_menu_key(key: Key, app: &mut App) {
       || key == Key::Down =>
     {
       if let Some(menu) = app.action_menu.as_mut() {
-        menu.handle_scroll(false, false);
+        menu.handle_scroll(ScrollEvent::down());
       }
     }
     _ if key == DEFAULT_KEYBINDING.submit.key => {
@@ -613,8 +613,8 @@ async fn handle_cordon_toggle(app: &mut App) {
 pub async fn handle_mouse_events(mouse: MouseEvent, app: &mut App) {
   match mouse.kind {
     // mouse scrolling is inverted
-    MouseEventKind::ScrollDown => handle_block_scroll(app, true, true, false).await,
-    MouseEventKind::ScrollUp => handle_block_scroll(app, false, true, false).await,
+    MouseEventKind::ScrollDown => handle_block_scroll(app, ScrollEvent::down(), true).await,
+    MouseEventKind::ScrollUp => handle_block_scroll(app, ScrollEvent::up(), true).await,
     _ => {}
   }
 }
@@ -1414,8 +1414,25 @@ fn handle_block_action<T: Clone>(key: Key, item: &StatefulTable<T>) -> Option<T>
   }
 }
 
-async fn handle_block_scroll(app: &mut App, up: bool, is_mouse: bool, page: bool) {
-  handle_resource_scroll!(app.get_current_route().active_block, app, up, page,
+#[derive(Debug, PartialEq, Eq)]
+pub enum ScrollEvent {
+  /// Scroll to an absolute position (negative indices either wrap around or scroll to the top)
+  #[allow(dead_code)]
+  Absolute(isize),
+  Relative(isize),
+}
+
+impl ScrollEvent {
+  pub fn down() -> Self {
+    ScrollEvent::Relative(1)
+  }
+  pub fn up() -> Self {
+    ScrollEvent::Relative(-1)
+  }
+}
+
+async fn handle_block_scroll(app: &mut App, event: ScrollEvent, is_mouse: bool) {
+  handle_resource_scroll!(app.get_current_route().active_block, app, event, is_mouse,
     [
       (ActiveBlock::Namespaces, namespaces),
       (ActiveBlock::Pods, pods),
@@ -1445,29 +1462,29 @@ async fn handle_block_scroll(app: &mut App, up: bool, is_mouse: bool, page: bool
       (ActiveBlock::DynamicResource, dynamic_resources),
     ],
     extra: {
-      ActiveBlock::Contexts => app.data.contexts.handle_scroll(up, page),
-      ActiveBlock::Utilization => app.data.metrics.handle_scroll(up, page),
-      ActiveBlock::Troubleshoot => app.data.troubleshoot_findings.handle_scroll(up, page),
-      ActiveBlock::Help => app.help_docs.handle_scroll(up, page),
+      ActiveBlock::Contexts => app.data.contexts.handle_scroll(event),
+      ActiveBlock::Utilization => app.data.metrics.handle_scroll(event),
+      ActiveBlock::Troubleshoot => app.data.troubleshoot_findings.handle_scroll(event),
+      ActiveBlock::Help => app.help_docs.handle_scroll(event),
       ActiveBlock::More => {
         let filtered_len = filter_menu_items(&app.more_resources_menu.items, &app.menu_filter).len();
-        handle_menu_scroll(&mut app.more_resources_menu, up, page, filtered_len);
+        handle_menu_scroll(&mut app.more_resources_menu, event, filtered_len);
       }
       ActiveBlock::DynamicView => {
         let filtered_len = filter_menu_items(&app.dynamic_resources_menu.items, &app.menu_filter).len();
-        handle_menu_scroll(&mut app.dynamic_resources_menu, up, page, filtered_len);
+        handle_menu_scroll(&mut app.dynamic_resources_menu, event, filtered_len);
       }
       ActiveBlock::Logs => {
         if app.log_auto_scroll {
           app.data.logs.freeze_follow_position();
           app.log_auto_scroll = false;
         }
-        app.data.logs.handle_scroll(inverse_dir(up, is_mouse), page);
+        app.data.logs.handle_scroll(inverse_dir(event, is_mouse));
       }
       ActiveBlock::Describe | ActiveBlock::Yaml => app
         .data
         .describe_out
-        .handle_scroll(inverse_dir(up, is_mouse), page),
+        .handle_scroll(inverse_dir(event, is_mouse)),
     }
   )
 }
@@ -1475,31 +1492,20 @@ async fn handle_block_scroll(app: &mut App, up: bool, is_mouse: bool, page: bool
 /// Scroll within a menu, respecting filtered item count
 fn handle_menu_scroll(
   menu: &mut StatefulList<(String, ActiveBlock)>,
-  up: bool,
-  page: bool,
+  event: ScrollEvent,
   filtered_len: usize,
 ) {
   if filtered_len == 0 {
     return;
   }
-  let increment = if page { 5 } else { 1 };
-  let i = match menu.state.selected() {
-    Some(i) => {
-      if up {
-        if i == 0 {
-          filtered_len.saturating_sub(increment)
-        } else {
-          i.saturating_sub(increment)
-        }
-      } else if i >= filtered_len.saturating_sub(increment) {
-        0
-      } else {
-        i + increment
-      }
-    }
-    None => 0,
-  };
-  menu.state.select(Some(i));
+
+  // duplicated because we wrap at filtered_len, not total len
+  let newpos = match event {
+    ScrollEvent::Absolute(newpos) => newpos % (filtered_len as isize),
+    ScrollEvent::Relative(delta) => menu.current_pos().unwrap_or(0) as isize + delta,
+  }
+  .rem_euclid(filtered_len as isize);
+  menu.state.select(Some(newpos as usize));
 }
 
 fn copy_to_clipboard(content: String, app: &mut App) {
@@ -1560,11 +1566,10 @@ fn format_error_history(history: &std::collections::VecDeque<crate::app::ErrorRe
 }
 
 /// inverse direction for natural scrolling on mouse and keyboard
-fn inverse_dir(up: bool, is_mouse: bool) -> bool {
-  if is_mouse {
-    !up
-  } else {
-    up
+fn inverse_dir(event: ScrollEvent, is_mouse: bool) -> ScrollEvent {
+  match event {
+    ScrollEvent::Relative(delta) if is_mouse => ScrollEvent::Relative(-delta),
+    other => other,
   }
 }
 
@@ -1593,8 +1598,8 @@ mod tests {
 
   #[test]
   fn test_inverse_dir() {
-    assert!(inverse_dir(true, false));
-    assert!(!inverse_dir(true, true));
+    assert_eq!(inverse_dir(ScrollEvent::down(), false), ScrollEvent::down());
+    assert_eq!(inverse_dir(ScrollEvent::down(), true), ScrollEvent::up());
   }
 
   fn temp_test_dir(name: &str) -> std::path::PathBuf {
@@ -2837,9 +2842,9 @@ mod tests {
 
     // mouse scroll
     assert_eq!(app.data.pods.state.selected(), Some(0));
-    handle_block_scroll(&mut app, false, true, false).await;
+    handle_block_scroll(&mut app, ScrollEvent::down(), true).await;
     assert_eq!(app.data.pods.state.selected(), Some(1));
-    handle_block_scroll(&mut app, true, true, false).await;
+    handle_block_scroll(&mut app, ScrollEvent::up(), true).await;
     assert_eq!(app.data.pods.state.selected(), Some(0));
 
     // check logs keyboard scroll
@@ -2850,7 +2855,7 @@ mod tests {
     app.data.logs.add_record("record 2".to_string());
     app.data.logs.add_record("record 3".to_string());
 
-    handle_block_scroll(&mut app, true, false, false).await;
+    handle_block_scroll(&mut app, ScrollEvent::down(), false).await;
     assert_eq!(app.data.logs.state.selected(), Some(0));
   }
 
@@ -3114,15 +3119,15 @@ mod tests {
 
     // Scroll down within filtered_len=2
     menu.state.select(Some(0));
-    handle_menu_scroll(&mut menu, false, false, 2);
+    handle_menu_scroll(&mut menu, ScrollEvent::down(), 2);
     assert_eq!(menu.state.selected(), Some(1));
 
     // Scroll down wraps at filtered_len
-    handle_menu_scroll(&mut menu, false, false, 2);
+    handle_menu_scroll(&mut menu, ScrollEvent::down(), 2);
     assert_eq!(menu.state.selected(), Some(0));
 
     // Scroll up from 0 wraps to end of filtered
-    handle_menu_scroll(&mut menu, true, false, 2);
+    handle_menu_scroll(&mut menu, ScrollEvent::up(), 2);
     assert_eq!(menu.state.selected(), Some(1));
   }
 
@@ -3131,7 +3136,7 @@ mod tests {
     let mut menu = StatefulList::with_items(vec![("A".into(), ActiveBlock::CronJobs)]);
     menu.state.select(Some(0));
     // Should not panic with filtered_len=0
-    handle_menu_scroll(&mut menu, false, false, 0);
+    handle_menu_scroll(&mut menu, ScrollEvent::Relative(0), 0);
     assert_eq!(menu.state.selected(), Some(0));
   }
 

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -618,7 +618,8 @@ async fn handle_cordon_toggle(app: &mut App) {
 
 pub async fn handle_mouse_events(mouse: MouseEvent, app: &mut App) {
   match mouse.kind {
-    // mouse scrolling is inverted
+    // mouse scrolling is inverted by passing is_mouse=true downstream code
+    // which calls [inverse_dir] where intended for mouse input
     MouseEventKind::ScrollDown => handle_block_scroll(app, ScrollEvent::down(), true).await,
     MouseEventKind::ScrollUp => handle_block_scroll(app, ScrollEvent::up(), true).await,
     _ => {}
@@ -1508,7 +1509,7 @@ fn handle_menu_scroll(
 
   // duplicated because we wrap at filtered_len, not total len
   let newpos = match event {
-    ScrollEvent::Absolute(newpos) => newpos % (filtered_len as isize),
+    ScrollEvent::Absolute(newpos) => newpos,
     ScrollEvent::Relative(delta) => menu.current_pos().unwrap_or(0) as isize + delta,
     ScrollEvent::End => filtered_len as isize - 1,
   }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -185,6 +185,12 @@ pub async fn handle_key_events(key: Key, key_event: KeyEvent, app: &mut App) {
       _ if key == DEFAULT_KEYBINDING.pg_down.key => {
         handle_block_scroll(app, ScrollEvent::Relative(10), false).await;
       }
+      _ if key == DEFAULT_KEYBINDING.home.key => {
+        handle_block_scroll(app, ScrollEvent::Absolute(0), false).await;
+      }
+      _ if key == DEFAULT_KEYBINDING.end.key => {
+        handle_block_scroll(app, ScrollEvent::End, false).await;
+      }
       _ if key == DEFAULT_KEYBINDING.toggle_theme.key => {
         app.light_theme = !app.light_theme;
       }
@@ -1417,9 +1423,10 @@ fn handle_block_action<T: Clone>(key: Key, item: &StatefulTable<T>) -> Option<T>
 #[derive(Debug, PartialEq, Eq)]
 pub enum ScrollEvent {
   /// Scroll to an absolute position (negative indices either wrap around or scroll to the top)
-  #[allow(dead_code)]
   Absolute(isize),
   Relative(isize),
+  /// Scroll to the end position (which might not have a known absolute position)
+  End,
 }
 
 impl ScrollEvent {
@@ -1503,6 +1510,7 @@ fn handle_menu_scroll(
   let newpos = match event {
     ScrollEvent::Absolute(newpos) => newpos % (filtered_len as isize),
     ScrollEvent::Relative(delta) => menu.current_pos().unwrap_or(0) as isize + delta,
+    ScrollEvent::End => filtered_len as isize - 1,
   }
   .rem_euclid(filtered_len as isize);
   menu.state.select(Some(newpos as usize));
@@ -2846,6 +2854,8 @@ mod tests {
     assert_eq!(app.data.pods.state.selected(), Some(1));
     handle_block_scroll(&mut app, ScrollEvent::up(), true).await;
     assert_eq!(app.data.pods.state.selected(), Some(0));
+    handle_block_scroll(&mut app, ScrollEvent::End, false).await;
+    assert_eq!(app.data.pods.state.selected(), Some(1));
 
     // check logs keyboard scroll
     app.push_navigation_stack(RouteId::Home, ActiveBlock::Logs);

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -127,7 +127,7 @@ mod tests {
     assert_eq!(
       lines,
       vec![
-        "┌ Help [46] filter </> · back <Esc> ───────────────────────────────────────────────────────────────┐",
+        "┌ Help [48] filter </> · back <Esc> ───────────────────────────────────────────────────────────────┐",
         "│   Key                                               Action                                  Conte│",
         "│=> <Ctrl+c> | <q>                                    Quit                                    Gener│",
         "│   <Esc>                                             Close child page/Go back                Gener│",
@@ -171,7 +171,7 @@ mod tests {
       .map(|col| buffer[(col, 0)].symbol())
       .collect();
 
-    assert!(first_line.contains("Help [1/46] [pod] · clear <Esc>"));
+    assert!(first_line.contains("Help [1/48] [pod] · clear <Esc>"));
     assert!(!first_line.contains("back <Esc>"));
   }
 }


### PR DESCRIPTION
This PR unifies the scrolling handling (both for wrapping as well as clamping lists/tables) and adds bindings for the `home`/`pos1` and `end` keys