### PR TITLE
fix: pass selected context to kubectl shell commands

### DIFF
--- a/src/cmd/edit.rs
+++ b/src/cmd/edit.rs
@@ -1,6 +1,6 @@
 use std::process::{Command, ExitStatus, Stdio};
 
-use super::is_valid_kubectl_arg;
+use super::{is_valid_kubectl_arg, push_context_arg};
 
 /// The resource to open in `$EDITOR` via `kubectl edit`. `namespace` is `None`
 /// for cluster-scoped kinds (nodes, PVs, cluster roles, …).
@@ -9,6 +9,8 @@ pub struct EditTarget {
   pub namespace: Option<String>,
   pub kind: String,
   pub name: String,
+  /// In-app selected context, or `None` to use the kubeconfig default (#532).
+  pub context: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -23,6 +25,7 @@ pub enum EditPrepareError {
   InvalidNamespace,
   InvalidKind,
   InvalidName,
+  InvalidContext,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -38,6 +41,7 @@ impl std::fmt::Display for EditPrepareError {
       Self::InvalidNamespace => write!(f, "Invalid namespace for edit"),
       Self::InvalidKind => write!(f, "Invalid resource kind for edit"),
       Self::InvalidName => write!(f, "Invalid resource name for edit"),
+      Self::InvalidContext => write!(f, "Invalid context for edit"),
     }
   }
 }
@@ -87,6 +91,11 @@ fn validate_target(target: &EditTarget) -> Result<(), EditPrepareError> {
   if let Some(namespace) = target.namespace.as_ref() {
     validate_component(namespace, EditPrepareError::InvalidNamespace)?;
   }
+  if let Some(context) = target.context.as_deref() {
+    if !is_valid_kubectl_arg(context) {
+      return Err(EditPrepareError::InvalidContext);
+    }
+  }
   Ok(())
 }
 
@@ -104,6 +113,7 @@ fn build_edit_command(target: &EditTarget) -> EditCommand {
     args.push("-n".into());
     args.push(namespace.clone());
   }
+  push_context_arg(&mut args, target.context.as_deref());
   EditCommand {
     program: "kubectl".into(),
     args,
@@ -126,6 +136,7 @@ mod tests {
       namespace: Some("default".into()),
       kind: "deployment".into(),
       name: "web".into(),
+      context: None,
     })
     .expect("edit command should prepare");
 
@@ -142,10 +153,35 @@ mod tests {
       namespace: None,
       kind: "node".into(),
       name: "node-1".into(),
+      context: None,
     })
     .expect("edit command should prepare");
 
     assert_eq!(command.args, vec!["edit", "node", "node-1"]);
+  }
+
+  #[test]
+  fn test_prepare_edit_includes_selected_context() {
+    let command = prepare_edit(&EditTarget {
+      namespace: Some("default".into()),
+      kind: "deployment".into(),
+      name: "web".into(),
+      context: Some("prod".into()),
+    })
+    .expect("edit command should prepare");
+
+    assert_eq!(
+      command.args,
+      vec![
+        "edit",
+        "deployment",
+        "web",
+        "-n",
+        "default",
+        "--context",
+        "prod"
+      ]
+    );
   }
 
   #[test]
@@ -155,6 +191,7 @@ mod tests {
         namespace: Some("default; rm -rf /".into()),
         kind: "deployment".into(),
         name: "web".into(),
+        context: None,
       }),
       Err(EditPrepareError::InvalidNamespace)
     );
@@ -164,6 +201,7 @@ mod tests {
         namespace: Some("default".into()),
         kind: "deploy`whoami`".into(),
         name: "web".into(),
+        context: None,
       }),
       Err(EditPrepareError::InvalidKind)
     );
@@ -173,8 +211,19 @@ mod tests {
         namespace: Some("default".into()),
         kind: "deployment".into(),
         name: String::new(),
+        context: None,
       }),
       Err(EditPrepareError::InvalidName)
+    );
+
+    assert_eq!(
+      prepare_edit(&EditTarget {
+        namespace: Some("default".into()),
+        kind: "deployment".into(),
+        name: "web".into(),
+        context: Some("prod`whoami`".into()),
+      }),
+      Err(EditPrepareError::InvalidContext)
     );
   }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -59,6 +59,17 @@ pub(crate) fn is_valid_kubectl_arg(s: &str) -> bool {
     && !s.contains('$')
 }
 
+/// Append `--context <name>` when an in-app context is selected, so kubectl
+/// targets the same cluster the `Shift+C` context switch points at rather than
+/// the kubeconfig's `current-context` (#532). No-op when no context is selected,
+/// matching the kube-rs client which then infers from the kubeconfig.
+pub(crate) fn push_context_arg(args: &mut Vec<String>, context: Option<&str>) {
+  if let Some(context) = context {
+    args.push("--context".into());
+    args.push(context.into());
+  }
+}
+
 impl<'a> CmdRunner<'a> {
   pub fn new(app: &'a Arc<Mutex<App>>) -> Self {
     CmdRunner { app }
@@ -263,14 +274,28 @@ impl<'a> CmdRunner<'a> {
       }
     }
 
+    let context = {
+      let app = self.app.lock().await;
+      app.data.selected.context.clone()
+    };
+    if let Some(ref context) = context {
+      if !is_valid_kubectl_arg(context) {
+        self
+          .handle_error(anyhow!("Invalid characters in context"))
+          .await;
+        return;
+      }
+    }
+
     let kind_clone = kind.clone();
     let result = tokio::task::spawn_blocking(move || {
-      let mut args = vec!["describe", kind.as_str(), value.as_str()];
+      let mut args = vec!["describe".to_string(), kind, value];
 
-      if let Some(ns) = ns.as_ref() {
-        args.push("-n");
-        args.push(ns.as_str());
+      if let Some(ns) = ns {
+        args.push("-n".to_string());
+        args.push(ns);
       }
+      push_context_arg(&mut args, context.as_deref());
 
       duct::cmd("kubectl", &args).stderr_null().read()
     })

--- a/src/cmd/port_forward.rs
+++ b/src/cmd/port_forward.rs
@@ -1,4 +1,4 @@
-use super::is_valid_kubectl_arg;
+use super::{is_valid_kubectl_arg, push_context_arg};
 
 /// A pod or service to forward to a local port. `kind` is the kubectl resource
 /// type (`pods` / `services`); ports are validated as `u16` so they never need
@@ -10,6 +10,8 @@ pub struct PortForwardTarget {
   pub name: String,
   pub local_port: u16,
   pub remote_port: u16,
+  /// In-app selected context, or `None` to use the kubeconfig default (#532).
+  pub context: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -24,6 +26,7 @@ pub enum PortForwardPrepareError {
   InvalidKind,
   InvalidNamespace,
   InvalidName,
+  InvalidContext,
 }
 
 impl std::fmt::Display for PortForwardPrepareError {
@@ -32,6 +35,7 @@ impl std::fmt::Display for PortForwardPrepareError {
       Self::InvalidKind => write!(f, "Invalid resource kind for port-forward"),
       Self::InvalidNamespace => write!(f, "Invalid namespace for port-forward"),
       Self::InvalidName => write!(f, "Invalid resource name for port-forward"),
+      Self::InvalidContext => write!(f, "Invalid context for port-forward"),
     }
   }
 }
@@ -46,14 +50,20 @@ pub fn prepare_port_forward(
   validate_component(&target.kind, PortForwardPrepareError::InvalidKind)?;
   validate_component(&target.namespace, PortForwardPrepareError::InvalidNamespace)?;
   validate_component(&target.name, PortForwardPrepareError::InvalidName)?;
+  if let Some(context) = target.context.as_deref() {
+    if !is_valid_kubectl_arg(context) {
+      return Err(PortForwardPrepareError::InvalidContext);
+    }
+  }
 
-  let args = vec![
+  let mut args = vec![
     "port-forward".into(),
     format!("{}/{}", target.kind, target.name),
     "-n".into(),
     target.namespace.clone(),
     format!("{}:{}", target.local_port, target.remote_port),
   ];
+  push_context_arg(&mut args, target.context.as_deref());
 
   Ok(PortForwardCommand {
     program: "kubectl".into(),
@@ -83,6 +93,7 @@ mod tests {
       name: "web".into(),
       local_port: 8080,
       remote_port: 80,
+      context: None,
     }
   }
 
@@ -111,6 +122,26 @@ mod tests {
   }
 
   #[test]
+  fn test_prepare_port_forward_includes_selected_context() {
+    let mut with_context = target();
+    with_context.context = Some("prod".into());
+    let command = prepare_port_forward(&with_context).expect("command should prepare");
+
+    assert_eq!(
+      command.args,
+      vec![
+        "port-forward",
+        "pods/web",
+        "-n",
+        "default",
+        "8080:80",
+        "--context",
+        "prod"
+      ]
+    );
+  }
+
+  #[test]
   fn test_prepare_port_forward_rejects_injection() {
     let mut invalid = target();
     invalid.name = "web; rm -rf /".into();
@@ -131,6 +162,13 @@ mod tests {
     assert_eq!(
       prepare_port_forward(&invalid),
       Err(PortForwardPrepareError::InvalidKind)
+    );
+
+    let mut invalid = target();
+    invalid.context = Some("prod;reboot".into());
+    assert_eq!(
+      prepare_port_forward(&invalid),
+      Err(PortForwardPrepareError::InvalidContext)
     );
   }
 }

--- a/src/cmd/shell.rs
+++ b/src/cmd/shell.rs
@@ -2,7 +2,7 @@ use std::process::{Command, ExitStatus, Stdio};
 
 use anyhow::anyhow;
 
-use super::is_valid_kubectl_arg;
+use super::{is_valid_kubectl_arg, push_context_arg};
 
 const SHELL_CANDIDATES: [&str; 2] = ["/bin/bash", "/bin/sh"];
 
@@ -11,6 +11,8 @@ pub struct ShellExecTarget {
   pub namespace: String,
   pub pod: String,
   pub container: String,
+  /// In-app selected context, or `None` to use the kubeconfig default (#532).
+  pub context: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -32,6 +34,7 @@ pub enum ShellExecPrepareError {
   InvalidNamespace,
   InvalidPod,
   InvalidContainer,
+  InvalidContext,
   UnsupportedShell,
   ProbeFailed(String),
 }
@@ -49,6 +52,7 @@ impl std::fmt::Display for ShellExecPrepareError {
       Self::InvalidNamespace => write!(f, "Invalid namespace for shell exec"),
       Self::InvalidPod => write!(f, "Invalid pod name for shell exec"),
       Self::InvalidContainer => write!(f, "Invalid container name for shell exec"),
+      Self::InvalidContext => write!(f, "Invalid context for shell exec"),
       Self::UnsupportedShell => write!(f, "Unable to find a supported shell in the container"),
       Self::ProbeFailed(message) => write!(f, "Unable to probe container shell support: {message}"),
     }
@@ -117,6 +121,11 @@ fn validate_target(target: &ShellExecTarget) -> Result<(), ShellExecPrepareError
   validate_component(&target.namespace, ShellExecPrepareError::InvalidNamespace)?;
   validate_component(&target.pod, ShellExecPrepareError::InvalidPod)?;
   validate_component(&target.container, ShellExecPrepareError::InvalidContainer)?;
+  if let Some(context) = target.context.as_deref() {
+    if !is_valid_kubectl_arg(context) {
+      return Err(ShellExecPrepareError::InvalidContext);
+    }
+  }
   Ok(())
 }
 
@@ -132,37 +141,41 @@ fn validate_component(
 }
 
 fn build_shell_exec_command(target: &ShellExecTarget, shell: &str) -> ShellExecCommand {
+  let mut args = vec!["exec".into()];
+  push_context_arg(&mut args, target.context.as_deref());
+  args.extend([
+    "-it".into(),
+    "-n".into(),
+    target.namespace.clone(),
+    target.pod.clone(),
+    "-c".into(),
+    target.container.clone(),
+    "--".into(),
+    shell.into(),
+  ]);
   ShellExecCommand {
     program: "kubectl".into(),
-    args: vec![
-      "exec".into(),
-      "-it".into(),
-      "-n".into(),
-      target.namespace.clone(),
-      target.pod.clone(),
-      "-c".into(),
-      target.container.clone(),
-      "--".into(),
-      shell.into(),
-    ],
+    args,
     shell: shell.into(),
   }
 }
 
 fn probe_shell_support(target: &ShellExecTarget, shell: &str) -> ShellProbeResult {
+  let mut args = vec!["exec".to_string()];
+  push_context_arg(&mut args, target.context.as_deref());
+  args.extend([
+    "-n".into(),
+    target.namespace.clone(),
+    target.pod.clone(),
+    "-c".into(),
+    target.container.clone(),
+    "--".into(),
+    shell.into(),
+    "-c".into(),
+    "exit".into(),
+  ]);
   let output = Command::new("kubectl")
-    .args([
-      "exec",
-      "-n",
-      target.namespace.as_str(),
-      target.pod.as_str(),
-      "-c",
-      target.container.as_str(),
-      "--",
-      shell,
-      "-c",
-      "exit",
-    ])
+    .args(&args)
     .stdin(Stdio::null())
     .stdout(Stdio::null())
     .output();
@@ -214,6 +227,7 @@ mod tests {
       namespace: "default".into(),
       pod: "api-123".into(),
       container: "web".into(),
+      context: None,
     }
   }
 
@@ -241,6 +255,41 @@ mod tests {
       ]
     );
     assert_eq!(command.shell, "/bin/bash");
+  }
+
+  #[test]
+  fn test_prepare_shell_exec_includes_context_before_separator() {
+    let mut with_context = target();
+    with_context.context = Some("prod".into());
+    let command = prepare_shell_exec_with_probe(&with_context, |_, _| ShellProbeResult::Supported)
+      .expect("shell command should prepare");
+
+    assert_eq!(
+      command.args,
+      vec![
+        "exec",
+        "--context",
+        "prod",
+        "-it",
+        "-n",
+        "default",
+        "api-123",
+        "-c",
+        "web",
+        "--",
+        "/bin/bash",
+      ]
+    );
+  }
+
+  #[test]
+  fn test_prepare_shell_exec_rejects_invalid_context() {
+    let mut invalid = target();
+    invalid.context = Some("prod; rm -rf /".into());
+    assert_eq!(
+      prepare_shell_exec_with_probe(&invalid, |_, _| ShellProbeResult::Supported),
+      Err(ShellExecPrepareError::InvalidContext)
+    );
   }
 
   #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -436,11 +436,13 @@ async fn execute_pending_shell_exec(
   terminal: &mut Terminal<CrosstermBackend<Stdout>>,
   request: app::PendingShellExec,
 ) -> Result<()> {
-  execute_pending_shell_exec_with(app, terminal, request, |request| {
+  let context = app.lock().await.data.selected.context.clone();
+  execute_pending_shell_exec_with(app, terminal, request, move |request| {
     let target = ShellExecTarget {
       namespace: request.namespace,
       pod: request.pod,
       container: request.container,
+      context,
     };
     let command = prepare_shell_exec(&target).map_err(|error| anyhow!(error.to_string()))?;
     let shell = command.shell.clone();
@@ -455,11 +457,13 @@ async fn execute_pending_edit(
   terminal: &mut Terminal<CrosstermBackend<Stdout>>,
   request: app::PendingEdit,
 ) -> Result<()> {
-  execute_pending_edit_with(app, terminal, request, |request| {
+  let context = app.lock().await.data.selected.context.clone();
+  execute_pending_edit_with(app, terminal, request, move |request| {
     let target = EditTarget {
       namespace: request.namespace,
       kind: request.kind,
       name: request.name,
+      context,
     };
     let command = prepare_edit(&target).map_err(|error| anyhow!(error.to_string()))?;
     run_edit(&command).map_err(|error| anyhow!(error.to_string()))?;

--- a/src/network/stream.rs
+++ b/src/network/stream.rs
@@ -670,12 +670,14 @@ impl<'a> NetworkStream<'a> {
     local_port: u16,
     remote_port: u16,
   ) {
+    let context = self.app.lock().await.data.selected.context.clone();
     let target = PortForwardTarget {
       kind,
       namespace,
       name,
       local_port,
       remote_port,
+      context,
     };
     let command = match prepare_port_forward(&target) {
       Ok(command) => command,


### PR DESCRIPTION
## Problem

Fixes #532.

KDash talks to Kubernetes two ways, and they disagreed on which context is active:

- kube-rs API calls (pod list, logs, scale, delete) are built from the context selected in-app with `Shift+C`.
- The kubectl shell commands (`describe`, `exec`, `edit`, `port-forward`) built their argv without `--context`, so they fell back to the kubeconfig `current-context`.

After switching context, those four commands ran against the wrong cluster and failed with errors like `Error running pod describe`, because the resource only existed in the selected cluster.

The reporter's `Shift+A` step is a red herring: `jump_to_current_context` just routes to the overview, it does not reset the selected context. The bug reproduces whenever the selected context differs from the kubeconfig default, with or without that step.

Logs (`l`) were never affected since they go through the kube-rs API, which already follows the switch.

## Fix

- Add a shared `push_context_arg` helper in `cmd/mod.rs`.
- Thread the selected context (`app.data.selected.context`) into the `describe`, `exec`, `edit`, and `port-forward` command builders and emit `--context <name>` when one is active.
- For `exec`, `--context` goes before the `--` separator so it is not passed to the in-container shell. The shell-support probe gets it too, so probing hits the right cluster.
- Validate the context like other kubectl args, with a new `InvalidContext` error per builder.

When no context is selected the flag is omitted, matching `get_client(None)` which infers from the kubeconfig, so default behaviour is unchanged.

## Testing

- New unit tests assert `--context` placement for exec/edit/port-forward and rejection of malformed context values.
- `cargo test` (435 passed), `cargo clippy --all --all-features --all-targets --workspace -- -D warnings`, and `cargo fmt` all clean.
