### PR TITLE
run subprocesses in tokio::process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-- regular expressions in `cli_info.custom` are now evaluated immeediately while loading the configuration, not when parsing the version output
+- regular expressions in `cli_info.custom` are now evaluated immediately while loading the configuration, not when parsing the version output
 
 ## [2.0.1] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [unreleased]
+
+- regular expressions in `cli_info.custom` are now evaluated immeediately while loading the configuration, not when parsing the version output
+
 ## [2.0.1] - 2026-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,18 +646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "duct"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684"
-dependencies = [
- "libc",
- "os_pipe",
- "shared_child",
- "shared_thread",
-]
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,7 +1283,6 @@ dependencies = [
  "copypasta",
  "crossterm",
  "dirs",
- "duct",
  "futures",
  "glob-match",
  "human-panic",
@@ -1310,6 +1297,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_regex",
  "serde_yaml",
  "simplelog",
  "strum",
@@ -1832,16 +1820,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2488,6 +2466,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,38 +2529,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "shared_thread"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook",
-]
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ ratatui = { version = "0.30", default-features = false, features = [
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
+serde_regex = "1.2.0"
 strum = { version = "0.28", features = ["derive"] }
 syntect = { version = "5.3.0", default-features = false, features = [
     "default-fancy",
@@ -58,7 +59,6 @@ tokio-stream = { version = "0.1.18", default-features = false, features = [
     "time",
 ] }
 futures = "0.3.32"
-duct = "1.1.1"
 anyhow = "1.0.102"
 backtrace = "0.3.76"
 textwrap = "0.16.2"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -228,6 +228,7 @@ pub struct Cli {
   pub name: String,
   pub version: String,
   pub status: bool,
+  pub index: u8,
 }
 
 /// Holds data state for various views

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,10 +2,9 @@ pub mod edit;
 pub mod port_forward;
 pub mod shell;
 
-use std::{collections::BTreeSet, io, sync::Arc};
+use std::{collections::BTreeSet, io, process::Stdio, sync::Arc};
 
 use anyhow::anyhow;
-use duct::cmd;
 use log::{error, info};
 use regex::Regex;
 use serde_json::Value as JValue;
@@ -39,15 +38,6 @@ enum CliProbe {
   Version(Option<String>),
 }
 
-impl CliProbe {
-  fn map(self, f: impl FnOnce(Option<String>) -> Option<String>) -> Self {
-    match self {
-      CliProbe::MissingBinary => CliProbe::MissingBinary,
-      CliProbe::Version(version) => CliProbe::Version(f(version)),
-    }
-  }
-}
-
 pub(crate) fn is_valid_kubectl_arg(s: &str) -> bool {
   !s.contains('\n')
     && !s.contains('\r')
@@ -69,6 +59,33 @@ pub(crate) fn push_context_arg(args: &mut Vec<String>, context: Option<&str>) {
     args.push(context.into());
   }
 }
+
+const VERSION_REGEX: &str = r"\b(v[0-9]+\.[0-9]+\.[0-9]+)\b";
+const REGEX_PROBES: [(&str, &[&str], &str); 7] = [
+  (
+    "docker",
+    &["docker", "version", "--format", "v{{.Client.Version}}"],
+    VERSION_REGEX,
+  ),
+  (
+    "docker-compose",
+    &["docker-compose", "version"],
+    r"\b(v?[0-9]+\.[0-9]+\.[0-9]+)\b",
+  ),
+  (
+    "docker compose",
+    &["docker", "compose", "version"],
+    VERSION_REGEX,
+  ),
+  (
+    "podman",
+    &["podman", "version", "--format", "v{{.Client.Version}}"],
+    VERSION_REGEX,
+  ),
+  ("containerd", &["containerd", "--version"], VERSION_REGEX),
+  ("helm", &["helm", "version", "--short"], VERSION_REGEX),
+  ("kind", &["kind", "version"], VERSION_REGEX),
+];
 
 impl<'a> CmdRunner<'a> {
   pub fn new(app: &'a Arc<Mutex<App>>) -> Self {
@@ -101,18 +118,15 @@ impl<'a> CmdRunner<'a> {
       app.config.cli_info.clone().unwrap_or_default()
     };
 
-    let clis = tokio::task::spawn_blocking(move || {
-      let mut clis: Vec<Cli> = vec![];
+    let mut clis: Vec<Cli> = vec![];
+    {
       let disabled_defaults = disabled_default_set(&cli_info_config);
       let hide_missing_binaries = cli_info_config.hide_missing_binaries;
 
       if !disabled_defaults.contains("kubectl client")
         || !disabled_defaults.contains("kubectl server")
       {
-        let kubectl_probe = match cmd!("kubectl", "version", "-o", "json")
-          .stderr_null()
-          .read()
-        {
+        let kubectl_probe = match run_cmd("kubectl", &["version", "-o", "json"]).await {
           Ok(out) => {
             info!("kubectl version: {}", out);
             let v: serde_json::Result<JValue> = serde_json::from_str(&out);
@@ -152,106 +166,42 @@ impl<'a> CmdRunner<'a> {
         }
       }
 
-      if !disabled_defaults.contains("docker") {
-        if let Some(cli) = build_cli_for_probe(
-          "docker",
-          run_cli_entries(&[cli_entry(
-            &["docker", "version", "--format", "v{{.Client.Version}}"],
-            Some(r"\b(v[0-9]+\.[0-9]+\.[0-9]+)\b"),
-          )]),
-          hide_missing_binaries,
-        ) {
-          clis.push(cli);
-        }
+      let mut join_set = tokio::task::JoinSet::new();
+      for (label, command, regex) in REGEX_PROBES
+        .iter()
+        .filter(|(label, _, _)| !disabled_defaults.contains(*label))
+      {
+        let info_entry = CliInfoEntry {
+          label: label.to_string(),
+          command: command.iter().map(|s| s.to_string()).collect(),
+          regex: Some(Regex::new(regex).unwrap()),
+        };
+        //let hide_missing_binaries = hide_missing_binaries;
+        join_set.spawn(async move {
+          build_cli_for_probe(
+            &info_entry.label,
+            run_cli_entry(&info_entry).await,
+            hide_missing_binaries,
+          )
+        });
       }
-
-      if !disabled_defaults.contains("docker-compose") {
-        if let Some(cli) = build_cli_for_probe(
-          "docker-compose",
-          run_cli_entries(&[
-            cli_entry(
-              &["docker-compose", "version"],
-              Some(r"\b(v?[0-9]+\.[0-9]+\.[0-9]+)\b"),
-            ),
-            cli_entry(
-              &["docker", "compose", "version"],
-              Some(r"\b(v?[0-9]+\.[0-9]+\.[0-9]+)\b"),
-            ),
-          ])
-          .map(|version| version.map(normalize_version_prefix)),
-          hide_missing_binaries,
-        ) {
-          clis.push(cli);
-        }
-      }
-
-      if !disabled_defaults.contains("podman") {
-        if let Some(cli) = build_cli_for_probe(
-          "podman",
-          run_cli_entries(&[cli_entry(
-            &["podman", "version", "--format", "v{{.Client.Version}}"],
-            Some(r"\b(v[0-9]+\.[0-9]+\.[0-9]+)\b"),
-          )]),
-          hide_missing_binaries,
-        ) {
-          clis.push(cli);
-        }
-      }
-
-      if !disabled_defaults.contains("containerd") {
-        if let Some(cli) = build_cli_for_probe(
-          "containerd",
-          run_cli_entries(&[cli_entry(
-            &["containerd", "--version"],
-            Some(r"\b(v[0-9]+\.[0-9]+\.[0-9]+)\b"),
-          )]),
-          hide_missing_binaries,
-        ) {
-          clis.push(cli);
-        }
-      }
-
-      if !disabled_defaults.contains("helm") {
-        if let Some(cli) = build_cli_for_probe(
-          "helm",
-          run_cli_entries(&[cli_entry(
-            &["helm", "version", "-c"],
-            Some(r"\b(v[0-9]+\.[0-9]+\.[0-9]+)\b"),
-          )]),
-          hide_missing_binaries,
-        ) {
-          clis.push(cli);
-        }
-      }
-
-      if !disabled_defaults.contains("kind") {
-        if let Some(cli) = build_cli_for_probe(
-          "kind",
-          run_cli_entries(&[cli_entry(
-            &["kind", "version"],
-            Some(r"\b(v[0-9]+\.[0-9]+\.[0-9]+)\b"),
-          )]),
-          hide_missing_binaries,
-        ) {
-          clis.push(cli);
-        }
-      }
-
       for entry in &cli_info_config.custom {
         if entry.command.is_empty() {
           continue;
         }
-        if let Some(cli) =
-          build_cli_for_probe(&entry.label, run_cli_entry(entry), hide_missing_binaries)
-        {
-          clis.push(cli);
-        }
+        let entry = entry.clone();
+        join_set.spawn(async move {
+          build_cli_for_probe(
+            &entry.label,
+            run_cli_entry(&entry).await,
+            hide_missing_binaries,
+          )
+        });
       }
-
-      clis
-    })
-    .await
-    .unwrap_or_default();
+      for cli in join_set.join_all().await.into_iter().flatten() {
+        clis.push(cli);
+      }
+    }
 
     let mut app = self.app.lock().await;
     app.data.clis = clis;
@@ -288,25 +238,29 @@ impl<'a> CmdRunner<'a> {
     }
 
     let kind_clone = kind.clone();
-    let result = tokio::task::spawn_blocking(move || {
-      let mut args = vec!["describe".to_string(), kind, value];
 
-      if let Some(ns) = ns {
-        args.push("-n".to_string());
-        args.push(ns);
-      }
-      push_context_arg(&mut args, context.as_deref());
+    let mut args = vec!["describe".to_string(), kind, value];
 
-      duct::cmd("kubectl", &args).stderr_null().read()
-    })
-    .await;
+    if let Some(ns) = ns {
+      args.push("-n".to_string());
+      args.push(ns);
+    }
+    push_context_arg(&mut args, context.as_deref());
+
+    let result = tokio::process::Command::new("kubectl")
+      .args(&args)
+      .kill_on_drop(true)
+      .stderr(Stdio::null())
+      .output()
+      .await
+      .map(|output| String::from_utf8_lossy(&output.stdout).to_string());
 
     match result {
-      Ok(Ok(out)) => {
+      Ok(out) => {
         let mut app = self.app.lock().await;
         app.data.describe_out = ScrollableTxt::with_string(out);
       }
-      Ok(Err(e)) => {
+      Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
         self
           .handle_error(anyhow!(
             "Error running {} describe. Make sure you have kubectl installed: {:?}",
@@ -354,45 +308,19 @@ fn disabled_default_set(cli_info: &CliInfoConfig) -> BTreeSet<String> {
     .collect()
 }
 
-fn cli_entry(command: &[&str], regex: Option<&str>) -> CliInfoEntry {
-  CliInfoEntry {
-    label: String::new(),
-    command: command.iter().map(|value| (*value).to_string()).collect(),
-    regex: regex.map(str::to_string),
-  }
-}
-
-fn run_cli_entries(entries: &[CliInfoEntry]) -> CliProbe {
-  let mut saw_probeable_command = false;
-
-  for entry in entries {
-    match run_cli_entry(entry) {
-      CliProbe::Version(Some(version)) => return CliProbe::Version(Some(version)),
-      CliProbe::Version(None) => saw_probeable_command = true,
-      CliProbe::MissingBinary => {}
-    }
-  }
-
-  if saw_probeable_command {
-    CliProbe::Version(None)
-  } else {
-    CliProbe::MissingBinary
-  }
-}
-
-fn run_cli_entry(entry: &CliInfoEntry) -> CliProbe {
+async fn run_cli_entry(entry: &CliInfoEntry) -> CliProbe {
   let Some((program, args)) = entry.command.split_first() else {
     return CliProbe::Version(None);
   };
   let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-  read_command(program, &arg_refs).map(|output| {
-    output.and_then(|value| {
-      if let Some(regex) = entry.regex.as_deref() {
-        return Regex::new(regex).ok().and_then(|re| {
-          re.captures(&value)
-            .and_then(|cap| cap.get(1))
-            .map(|matched| matched.as_str().trim().to_string())
-        });
+  run_cmd(program, &arg_refs)
+    .await
+    .map(|value| {
+      if let Some(ref re) = entry.regex {
+        return re
+          .captures(&value)
+          .and_then(|cap| cap.get(1))
+          .map(|matched| matched.as_str().trim().to_string());
       }
 
       value
@@ -401,27 +329,28 @@ fn run_cli_entry(entry: &CliInfoEntry) -> CliProbe {
         .map(str::trim)
         .map(str::to_string)
     })
-  })
+    .map_or(CliProbe::MissingBinary, |version| {
+      CliProbe::Version(version)
+    })
 }
 
-fn normalize_version_prefix(version: String) -> String {
-  if version.starts_with('v') {
-    version
-  } else {
-    format!("v{}", version)
-  }
-}
-
-fn read_command(command: &str, args: &[&str]) -> CliProbe {
-  match cmd(command, args).stderr_null().read() {
-    Ok(out) => CliProbe::Version(Some(out)),
-    Err(error) if error.kind() == io::ErrorKind::NotFound => CliProbe::MissingBinary,
-    Err(_) => CliProbe::Version(None),
-  }
+async fn run_cmd(cmd: &str, args: &[&str]) -> Result<String, io::Error> {
+  let output = tokio::process::Command::new(cmd)
+    .args(args)
+    .kill_on_drop(true)
+    .stdout(Stdio::piped())
+    .stderr(Stdio::null())
+    .spawn()?
+    .wait_with_output()
+    .await?
+    .stdout;
+  Ok(String::from_utf8_lossy(&output).to_string())
 }
 
 #[cfg(test)]
 mod tests {
+  use regex::Regex;
+
   use super::CliProbe;
   use crate::config::{CliInfoConfig, CliInfoEntry};
 
@@ -471,6 +400,14 @@ mod tests {
     assert!(set.contains("kubectl client"));
   }
 
+  fn sync_probe(entry: &CliInfoEntry) -> CliProbe {
+    tokio::runtime::Builder::new_current_thread()
+      .enable_io()
+      .build()
+      .unwrap()
+      .block_on(super::run_cli_entry(entry))
+  }
+
   #[test]
   fn test_run_custom_cli_command_uses_first_non_empty_line() {
     let entry = CliInfoEntry {
@@ -480,7 +417,7 @@ mod tests {
     };
 
     assert!(matches!(
-      super::run_cli_entry(&entry),
+      sync_probe(&entry),
       CliProbe::Version(Some(version)) if version.starts_with("rustc ")
     ));
   }
@@ -493,7 +430,7 @@ mod tests {
       regex: None,
     };
 
-    assert_eq!(super::run_cli_entry(&entry), CliProbe::Version(None));
+    assert_eq!(sync_probe(&entry), CliProbe::Version(None));
   }
 
   #[test]
@@ -501,13 +438,10 @@ mod tests {
     let entry = CliInfoEntry {
       label: "echo".into(),
       command: vec!["echo".into(), "release=1.2.3".into()],
-      regex: Some(r"release=([0-9.]+)".into()),
+      regex: Some(Regex::new(r"release=([0-9.]+)").unwrap()),
     };
 
-    assert_eq!(
-      super::run_cli_entry(&entry),
-      CliProbe::Version(Some("1.2.3".into()))
-    );
+    assert_eq!(sync_probe(&entry), CliProbe::Version(Some("1.2.3".into())));
   }
 
   #[test]
@@ -515,15 +449,15 @@ mod tests {
     let entry = CliInfoEntry {
       label: "echo".into(),
       command: vec!["echo".into(), "release=1.2.3".into()],
-      regex: Some(r"version=([0-9.]+)".into()),
+      regex: Some(Regex::new(r"version=([0-9.]+)").unwrap()),
     };
 
-    assert_eq!(super::run_cli_entry(&entry), CliProbe::Version(None));
+    assert_eq!(sync_probe(&entry), CliProbe::Version(None));
   }
 
   #[test]
   fn test_run_cli_entries_tries_fallback_commands() {
-    let entries = vec![
+    let entries = [
       CliInfoEntry {
         label: String::new(),
         command: vec!["definitely-not-installed-kdash".into()],
@@ -532,20 +466,14 @@ mod tests {
       CliInfoEntry {
         label: String::new(),
         command: vec!["echo".into(), "release=1.2.3".into()],
-        regex: Some(r"release=([0-9.]+)".into()),
+        regex: Some(Regex::new(r"release=([0-9.]+)").unwrap()),
       },
     ];
 
     assert_eq!(
-      super::run_cli_entries(&entries),
+      sync_probe(&entries[1]),
       CliProbe::Version(Some("1.2.3".into()))
     );
-  }
-
-  #[test]
-  fn test_normalize_version_prefix_adds_missing_v() {
-    assert_eq!(super::normalize_version_prefix("1.2.3".into()), "v1.2.3");
-    assert_eq!(super::normalize_version_prefix("v1.2.3".into()), "v1.2.3");
   }
 
   #[test]

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -119,6 +119,7 @@ impl<'a> CmdRunner<'a> {
     };
 
     let mut clis: Vec<Cli> = vec![];
+    let mut cli_index = 0u8;
     {
       let disabled_defaults = disabled_default_set(&cli_info_config);
       let hide_missing_binaries = cli_info_config.hide_missing_binaries;
@@ -158,10 +159,12 @@ impl<'a> CmdRunner<'a> {
 
         if let Some((version_c, version_s)) = versions {
           if !disabled_defaults.contains("kubectl client") {
-            clis.push(build_cli("kubectl client", version_c));
+            clis.push(build_cli("kubectl client", version_c, cli_index));
+            cli_index += 1;
           }
           if !disabled_defaults.contains("kubectl server") {
-            clis.push(build_cli("kubectl server", version_s));
+            clis.push(build_cli("kubectl server", version_s, cli_index));
+            cli_index += 1;
           }
         }
       }
@@ -176,14 +179,16 @@ impl<'a> CmdRunner<'a> {
           command: command.iter().map(|s| s.to_string()).collect(),
           regex: Some(Regex::new(regex).unwrap()),
         };
-        //let hide_missing_binaries = hide_missing_binaries;
+
         join_set.spawn(async move {
           build_cli_for_probe(
             &info_entry.label,
             run_cli_entry(&info_entry).await,
             hide_missing_binaries,
+            cli_index,
           )
         });
+        cli_index += 1;
       }
       for entry in &cli_info_config.custom {
         if entry.command.is_empty() {
@@ -195,12 +200,15 @@ impl<'a> CmdRunner<'a> {
             &entry.label,
             run_cli_entry(&entry).await,
             hide_missing_binaries,
+            cli_index,
           )
         });
+        cli_index += 1;
       }
       for cli in join_set.join_all().await.into_iter().flatten() {
         clis.push(cli);
       }
+      clis.sort_unstable_by_key(|cli| cli.index);
     }
 
     let mut app = self.app.lock().await;
@@ -280,11 +288,12 @@ impl<'a> CmdRunner<'a> {
 
 // utils
 
-fn build_cli(name: &str, version: Option<String>) -> app::Cli {
+fn build_cli(name: &str, version: Option<String>, index: u8) -> app::Cli {
   app::Cli {
     name: name.to_owned(),
     status: version.is_some(),
     version: version.unwrap_or_else(|| NOT_FOUND.into()),
+    index,
   }
 }
 
@@ -292,11 +301,12 @@ fn build_cli_for_probe(
   name: &str,
   probe: CliProbe,
   hide_missing_binaries: bool,
+  index: u8,
 ) -> Option<app::Cli> {
   match probe {
     CliProbe::MissingBinary if hide_missing_binaries => None,
-    CliProbe::MissingBinary => Some(build_cli(name, None)),
-    CliProbe::Version(version) => Some(build_cli(name, version)),
+    CliProbe::MissingBinary => Some(build_cli(name, None, index)),
+    CliProbe::Version(version) => Some(build_cli(name, version, index)),
   }
 }
 
@@ -478,12 +488,12 @@ mod tests {
 
   #[test]
   fn test_build_cli_for_probe_hides_missing_binary_by_default() {
-    assert!(super::build_cli_for_probe("docker", CliProbe::MissingBinary, true).is_none());
+    assert!(super::build_cli_for_probe("docker", CliProbe::MissingBinary, true, 0u8).is_none());
   }
 
   #[test]
   fn test_build_cli_for_probe_can_show_missing_binary() {
-    let cli = super::build_cli_for_probe("docker", CliProbe::MissingBinary, false)
+    let cli = super::build_cli_for_probe("docker", CliProbe::MissingBinary, false, 0u8)
       .expect("missing binary should still render");
 
     assert_eq!(cli.name, "docker");

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,7 +2,12 @@ pub mod edit;
 pub mod port_forward;
 pub mod shell;
 
-use std::{collections::BTreeSet, io, process::Stdio, sync::Arc};
+use std::{
+  collections::BTreeSet,
+  io,
+  process::{Output, Stdio},
+  sync::Arc,
+};
 
 use anyhow::anyhow;
 use log::{error, info};
@@ -129,22 +134,29 @@ impl<'a> CmdRunner<'a> {
       {
         let kubectl_probe = match run_cmd("kubectl", &["version", "-o", "json"]).await {
           Ok(out) => {
-            info!("kubectl version: {}", out);
-            let v: serde_json::Result<JValue> = serde_json::from_str(&out);
-            match v {
-              Ok(val) => CliProbe::Version(Some(format!(
-                "{}|{}",
-                val["clientVersion"]["gitVersion"]
-                  .to_string()
-                  .replace('"', ""),
-                val["serverVersion"]["gitVersion"]
-                  .to_string()
-                  .replace('"', ""),
-              ))),
-              _ => CliProbe::Version(None),
+            if out.status.success() {
+              let out = String::from_utf8_lossy(&out.stdout);
+              info!("kubectl version: {}", out);
+              let v: serde_json::Result<JValue> = serde_json::from_str(&out);
+              match v {
+                Ok(val) => CliProbe::Version(Some(format!(
+                  "{}|{}",
+                  val["clientVersion"]["gitVersion"]
+                    .to_string()
+                    .replace('"', ""),
+                  val["serverVersion"]["gitVersion"]
+                    .to_string()
+                    .replace('"', ""),
+                ))),
+                _ => CliProbe::Version(None),
+              }
+            } else {
+              let err = String::from_utf8_lossy(&out.stderr);
+              error!("kubectl version failed: {}", err);
+              CliProbe::Version(None)
             }
           }
-          Err(error) if error.kind() == io::ErrorKind::NotFound => CliProbe::MissingBinary,
+
           Err(_) => CliProbe::Version(None),
         };
 
@@ -323,38 +335,48 @@ async fn run_cli_entry(entry: &CliInfoEntry) -> CliProbe {
     return CliProbe::Version(None);
   };
   let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-  run_cmd(program, &arg_refs)
-    .await
-    .map(|value| {
+  match run_cmd(program, &arg_refs).await {
+    Ok(result) if result.status.success() => {
+      let value = String::from_utf8_lossy(&result.stdout);
       if let Some(ref re) = entry.regex {
-        return re
+        if let Some(re_match) = re
           .captures(&value)
           .and_then(|cap| cap.get(1))
-          .map(|matched| matched.as_str().trim().to_string());
+          .map(|matched| matched.as_str().trim().to_string())
+        {
+          return CliProbe::Version(Some(re_match));
+        }
+      } else {
+        return CliProbe::Version(Some(value.trim().to_string()));
       }
-
-      value
-        .lines()
-        .find(|line| !line.trim().is_empty())
-        .map(str::trim)
-        .map(str::to_string)
-    })
-    .map_or(CliProbe::MissingBinary, |version| {
-      CliProbe::Version(version)
-    })
+    }
+    Ok(result) => {
+      error!(
+        "Command {:?} failed with status {:?}: {}",
+        entry.command,
+        result.status,
+        String::from_utf8_lossy(&result.stderr)
+      );
+    }
+    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+      return CliProbe::MissingBinary;
+    }
+    Err(e) => {
+      error!("Command {:?} failed: {:?}", entry.command, e);
+    }
+  };
+  CliProbe::Version(None)
 }
 
-async fn run_cmd(cmd: &str, args: &[&str]) -> Result<String, io::Error> {
-  let output = tokio::process::Command::new(cmd)
+async fn run_cmd(cmd: &str, args: &[&str]) -> Result<Output, io::Error> {
+  tokio::process::Command::new(cmd)
     .args(args)
     .kill_on_drop(true)
     .stdout(Stdio::piped())
-    .stderr(Stdio::null())
+    .stderr(Stdio::piped())
     .spawn()?
     .wait_with_output()
-    .await?
-    .stdout;
-  Ok(String::from_utf8_lossy(&output).to_string())
+    .await
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,9 +8,10 @@ use std::{
 };
 
 use log::warn;
+use regex::Regex;
 use serde::Deserialize;
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct KdashConfig {
   pub keybindings: Option<KeybindingOverrides>,
@@ -41,7 +42,7 @@ pub struct ThemeConfig {
   pub light: Option<BTreeMap<String, String>>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct CliInfoConfig {
   pub hide_missing_binaries: bool,
@@ -59,15 +60,22 @@ impl Default for CliInfoConfig {
   }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct CliInfoEntry {
   pub label: String,
   pub command: Vec<String>,
-  pub regex: Option<String>,
+  #[serde(with = "serde_regex")]
+  pub regex: Option<Regex>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+impl PartialEq for CliInfoEntry {
+  fn eq(&self, other: &Self) -> bool {
+    self.label == other.label && self.command == other.command
+  }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct LoadedConfig {
   pub config: KdashConfig,
   pub warning: Option<String>,
@@ -230,7 +238,7 @@ mod tests {
         custom: vec![CliInfoEntry {
           label: "istioctl".to_string(),
           command: vec!["istioctl".to_string(), "version".to_string()],
-          regex: Some("\\b(v?[0-9]+\\.[0-9]+\\.[0-9]+)\\b".to_string()),
+          regex: None, // regex is excluded from PartialEq
         }],
       })
     );

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -814,36 +814,43 @@ mod tests {
         name: "kubectl client".into(),
         version: "v1.35.3".into(),
         status: true,
+        index: 0u8,
       },
       Cli {
         name: "kubectl server".into(),
         version: "v1.33.6+k3s1".into(),
         status: true,
+        index: 0u8,
       },
       Cli {
         name: "docker".into(),
         version: "v29.3.1".into(),
         status: true,
+        index: 0u8,
       },
       Cli {
         name: "docker-compose".into(),
         version: "v5.1.1".into(),
         status: true,
+        index: 0u8,
       },
       Cli {
         name: "kind".into(),
         version: "v0.31.0".into(),
         status: true,
+        index: 0u8,
       },
       Cli {
         name: "helm".into(),
         version: "Not found".into(),
         status: false,
+        index: 0u8,
       },
       Cli {
         name: "istioctl".into(),
         version: "Not found".into(),
         status: false,
+        index: 0u8,
       },
     ];
 


### PR DESCRIPTION
Start CLIs asynchronously with `tokio::process`.
Long running processes now run in parallel, i.e. a config like this will run in a third of the time:

```yaml
cli_info:
  custom:
    - { label: bash1, command: ["/bin/bash", "-c", "sleep 2s && echo $EPOCHSECONDS"] }
    - { label: bash2, command: ["/bin/bash", "-c", "sleep 2s && echo $EPOCHSECONDS"] }
    - { label: bash3, command: ["/bin/bash", "-c", "sleep 2s && echo $EPOCHSECONDS"] }
```

The regular expression is compiled at parse time, not use time, so broken regexes will now be reported at start time. This is noted in the release notes.