### PR TITLE
chore(deps): update kubernetes dependencies + serde_saphyr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [unreleased]
+
+### Changed
+
+- Kubernetes dependency updates
+- Configuration file parsing is handled by `serde_saphyr`. Keybindings need to quote `"n"`, `"y"`, `"t"` and `"f"`.
+
 ## [2.0.2] - 2026-06-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Changed
 
 - Kubernetes dependency updates
-- Configuration file parsing is handled by `serde_saphyr`. Keybindings need to quote `"n"`, `"y"`, `"t"` and `"f"`.
 
 ## [2.0.2] - 2026-06-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.1",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +58,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e4850548ff4a25a77ce3bda7241874e17fb702ea551f0cc62a2dbe052f1272"
+dependencies = [
+ "anstyle",
+ "unicode-width",
 ]
 
 [[package]]
@@ -111,6 +134,12 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "async-compression"
@@ -664,6 +693,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,8 +937,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
 
@@ -920,6 +969,16 @@ name = "glob-match"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
+
+[[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1305,6 +1364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,14 +1422,14 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "k8s-openapi"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b326f5219dd55872a72c1b6ddd1b830b8334996c667449c29391d657d78d5e"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
  "base64 0.22.1",
  "jiff",
@@ -1377,7 +1445,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1407,9 +1475,9 @@ dependencies = [
  "ratatui",
  "regex",
  "serde",
+ "serde-saphyr",
  "serde_json",
  "serde_regex",
- "serde_yaml",
  "simplelog",
  "strum",
  "syntect",
@@ -1440,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc5a6a69da2975ed9925d56b5dcfc9cc739b66f37add06785b7c9f6d1e88741"
+checksum = "4bb9108095346a7096d11feeaff419c75dddcac1b2f59acb38d7bf3d13c3e146"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -1451,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcaf2d1f1a91e1805d4cd82e8333c022767ae8ffd65909bbef6802733a7dd40"
+checksum = "d0f628e05bc2264c21fe10d3d675117dc9b43ea3bf4fb07262a222679757537b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1475,10 +1543,10 @@ dependencies = [
  "rustls",
  "secrecy",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "tame-oauth",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -1489,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "3.1.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f126d2db7a8b532ec1d839ece2a71e2485dc3bbca6cc3c3f929becaa810e719e"
+checksum = "c1b02f5933ba06140d58c7d6727f6c319f0962ec6a344aa5e21e475e891deaa8"
 dependencies = [
  "derive_more",
  "form_urlencoded",
@@ -1501,25 +1569,25 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "kubectl-view-allocations"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e61a219488d43c95674cd7dd48a766fafb3b6e696fd5c54c609d6234ae5d72"
+checksum = "7171950a397139c52d709d028af6641640a4f079d9ea5b56ddaf8287cffa3ab3"
 dependencies = [
  "chrono",
  "clap",
  "color-eyre",
  "futures",
- "itertools",
+ "itertools 0.15.0",
  "k8s-openapi",
  "kube",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-error",
 ]
@@ -1712,6 +1780,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "notify"
@@ -2248,13 +2322,13 @@ dependencies = [
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
  "palette",
  "serde",
  "strum",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -2282,7 +2356,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -2309,7 +2383,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.11",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2551,6 +2625,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.1",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,19 +2703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2858,7 +2938,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
 ]
@@ -2914,11 +2994,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2934,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3047,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -3213,9 +3293,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3224,8 +3304,7 @@ dependencies = [
  "log",
  "rand 0.9.3",
  "sha1",
- "thiserror 2.0.12",
- "utf-8",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3274,7 +3353,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -3292,12 +3371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,12 +3386,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4126,6 +4193,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ ratatui = { version = "0.30", default-features = false, features = [
 ] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde-saphyr = "0.0.27"
 serde_regex = "1.2.0"
 strum = { version = "0.28", features = ["derive"] }
 syntect = { version = "5.3.0", default-features = false, features = [
@@ -63,7 +63,7 @@ anyhow = "1.0.102"
 backtrace = "0.3.76"
 textwrap = "0.16.2"
 regex = "1.12.4"
-kube = { version = "3.1.0", default-features = false, features = [
+kube = { version = "4.0.0", default-features = false, features = [
     "socks5",
     "http-proxy",
     "client",
@@ -72,15 +72,15 @@ kube = { version = "3.1.0", default-features = false, features = [
     "oauth",
     "ws",
 ] }
-k8s-openapi = { version = "0.27.1", default-features = false, features = [
-    "v1_31",
+k8s-openapi = { version = "0.28.0", default-features = false, features = [
+    "earliest",
 ] }
 notify = { version = "8", default-features = false, features = [
     "macos_fsevent",
 ] }
 base64 = "0.22.1"
 human-panic = "2.0.8"
-kubectl-view-allocations = { version = "3.0.1", default-features = false }
+kubectl-view-allocations = { version = "3.0.2", default-features = false }
 async-trait = "0.1.89"
 glob-match = "0.2.1"
 rand = "0.10.1"

--- a/assets/kdash.sample-config.yaml
+++ b/assets/kdash.sample-config.yaml
@@ -45,7 +45,7 @@ keybindings:
   toggle_info: i
   log_auto_scroll: s
   select_all_namespace: a
-  jump_to_namespace: n
+  jump_to_namespace: "n" # needs to be quoted to avoid being interpreted as a boolean
   describe_resource: d
   resource_yaml: "y"
   decode_secret: x

--- a/assets/kdash.sample-config.yaml
+++ b/assets/kdash.sample-config.yaml
@@ -45,7 +45,7 @@ keybindings:
   toggle_info: i
   log_auto_scroll: s
   select_all_namespace: a
-  jump_to_namespace: "n" # needs to be quoted to avoid being interpreted as a boolean
+  jump_to_namespace: n
   describe_resource: d
   resource_yaml: "y"
   decode_secret: x

--- a/src/app/contexts.rs
+++ b/src/app/contexts.rs
@@ -193,6 +193,7 @@ mod tests {
         namespace: namespace.map(String::from),
         ..Default::default()
       }),
+      ..Default::default()
     }
   }
 

--- a/src/app/ingress.rs
+++ b/src/app/ingress.rs
@@ -141,7 +141,7 @@ fn get_rules(i_rules: &Option<Vec<IngressRule>>) -> Option<String> {
             rule = format!(
               "{}{}►{}",
               rule,
-              &path.path.clone().unwrap_or("/*".to_string()),
+              path.path.as_deref().unwrap_or("/*"),
               format_backend(&Some(path.backend.clone()))
             );
           });

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1685,7 +1685,7 @@ mod test_utils {
       .expect("Something went wrong reading yaml file");
     assert_ne!(yaml, "".to_string());
 
-    let res_list: serde_yaml::Result<ObjectList<K>> = serde_yaml::from_str(&yaml);
+    let res_list = serde_saphyr::from_str::<ObjectList<K>>(&yaml);
     assert!(res_list.is_ok(), "{:?}", res_list.err());
     res_list.unwrap()
   }

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -46,7 +46,7 @@ pub trait KubeResource<T: Serialize>: Named {
 
   /// generate YAML from the original kubernetes resource
   fn resource_to_yaml(&self) -> String {
-    match serde_yaml::to_string(&self.get_k8s_obj()) {
+    match serde_saphyr::to_string(&self.get_k8s_obj()) {
       Ok(yaml) => yaml,
       Err(_) => "".into(),
     }

--- a/src/app/ns.rs
+++ b/src/app/ns.rs
@@ -279,6 +279,7 @@ mod tests {
           namespace: Some("from-kubeconfig".into()),
           ..Default::default()
         }),
+        ..Default::default()
       }],
       ..Default::default()
     });

--- a/src/app/secrets.rs
+++ b/src/app/secrets.rs
@@ -44,13 +44,7 @@ impl KubeSecret {
 
     // decode each of the key/values in the secret
     for (key_name, encoded_bytes) in self.data.iter() {
-      let decoded_str = match serde_yaml::to_string(encoded_bytes) {
-        Ok(encoded_str) => match general_purpose::STANDARD.decode(encoded_str.trim()) {
-          Ok(decoded_bytes) => String::from_utf8_lossy(&decoded_bytes).into_owned(),
-          Err(_) => format!("cannot decode value: {}", encoded_str.trim()),
-        },
-        Err(_) => String::from("cannot deserialize value"),
-      };
+      let decoded_str = String::from_utf8_lossy(&encoded_bytes.0);
       let decoded_kv = format!("{}: {}\n", key_name, decoded_str);
       out.push_str(decoded_kv.as_str());
     }

--- a/src/app/secrets.rs
+++ b/src/app/secrets.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 
 use async_trait::async_trait;
-use base64::{engine::general_purpose, Engine};
 use chrono::Utc;
 use k8s_openapi::{api::core::v1::Secret, ByteString};
 use ratatui::{

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,7 +96,7 @@ pub fn config_path() -> Option<PathBuf> {
 }
 
 fn parse_config(contents: &str, path: &Path) -> LoadedConfig {
-  match serde_yaml::from_str::<KdashConfig>(contents) {
+  match serde_saphyr::from_str::<KdashConfig>(contents) {
     Ok(config) => LoadedConfig {
       config,
       warning: None,
@@ -297,7 +297,7 @@ mod tests {
   #[test]
   fn test_cli_info_defaults_hide_missing_binaries() {
     let config: KdashConfig =
-      serde_yaml::from_str("cli_info:\n  disable_defaults:\n    - docker\n")
+      serde_saphyr::from_str("cli_info:\n  disable_defaults:\n    - docker\n")
         .expect("config should parse");
 
     assert_eq!(
@@ -312,7 +312,7 @@ mod tests {
 
   #[test]
   fn test_cli_info_can_show_missing_binaries() {
-    let config: KdashConfig = serde_yaml::from_str("cli_info:\n  hide_missing_binaries: false\n")
+    let config: KdashConfig = serde_saphyr::from_str("cli_info:\n  hide_missing_binaries: false\n")
       .expect("config should parse");
 
     assert_eq!(
@@ -344,7 +344,7 @@ mod tests {
 
   #[test]
   fn test_default_theme_and_custom_theme_parse() {
-    let config: KdashConfig = serde_yaml::from_str(
+    let config: KdashConfig = serde_saphyr::from_str(
       "default_theme: gruvbox\ncustom_theme:\n  base: latte\n  accent: \"#FF00AA\"\n",
     )
     .expect("config should parse");
@@ -356,7 +356,7 @@ mod tests {
 
   #[test]
   fn test_hide_logo_and_info_default_to_false() {
-    let config: KdashConfig = serde_yaml::from_str("").expect("empty config should parse");
+    let config: KdashConfig = serde_saphyr::from_str("").expect("empty config should parse");
 
     assert!(!config.hide_logo);
     assert!(!config.hide_info_on_start);
@@ -364,7 +364,7 @@ mod tests {
 
   #[test]
   fn test_hide_logo_and_info_can_be_enabled() {
-    let config: KdashConfig = serde_yaml::from_str("hide_logo: true\nhide_info_on_start: true\n")
+    let config: KdashConfig = serde_saphyr::from_str("hide_logo: true\nhide_info_on_start: true\n")
       .expect("config should parse");
 
     assert!(config.hide_logo);
@@ -374,7 +374,7 @@ mod tests {
   #[test]
   fn test_cli_info_custom_regex_defaults_to_none() {
     let config: KdashConfig =
-      serde_yaml::from_str(
+      serde_saphyr::from_str(
         "cli_info:\n  custom:\n    - label: containerd\n      command: [\"containerd\", \"--version\"]\n",
       )
       .expect("config should parse");

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,7 +96,14 @@ pub fn config_path() -> Option<PathBuf> {
 }
 
 fn parse_config(contents: &str, path: &Path) -> LoadedConfig {
-  match serde_saphyr::from_str::<KdashConfig>(contents) {
+  // Restrict boolean resolution to `true`/`false` (YAML 1.2 core schema, matching
+  // the old serde_yaml). Without this, serde_saphyr resolves bare `n`/`y`/`t`/`f`
+  // as booleans, breaking existing unquoted single-letter keybindings.
+  let options = serde_saphyr::Options {
+    strict_booleans: true,
+    ..Default::default()
+  };
+  match serde_saphyr::from_str_with_options::<KdashConfig>(contents, options) {
     Ok(config) => LoadedConfig {
       config,
       warning: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,9 +99,8 @@ fn parse_config(contents: &str, path: &Path) -> LoadedConfig {
   // Restrict boolean resolution to `true`/`false` (YAML 1.2 core schema, matching
   // the old serde_yaml). Without this, serde_saphyr resolves bare `n`/`y`/`t`/`f`
   // as booleans, breaking existing unquoted single-letter keybindings.
-  let options = serde_saphyr::Options {
-    strict_booleans: true,
-    ..Default::default()
+  let options = serde_saphyr::options! {
+    strict_booleans: true
   };
   match serde_saphyr::from_str_with_options::<KdashConfig>(contents, options) {
     Ok(config) => LoadedConfig {

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1131,7 +1131,7 @@ users:
     let _proxy_env = ProxyEnvGuard::capture();
     clear_https_proxy_env();
 
-    let kubeconfig: Kubeconfig = serde_yaml::from_str(&kubeconfig_with_proxy(Some(
+    let kubeconfig: Kubeconfig = serde_saphyr::from_str(&kubeconfig_with_proxy(Some(
       "http://cluster-proxy.internal:8443",
     )))
     .expect("proxy kubeconfig should deserialize");
@@ -1157,7 +1157,7 @@ users:
     clear_https_proxy_env();
     env::set_var("HTTPS_PROXY", "http://env-proxy.internal:8080");
 
-    let kubeconfig: Kubeconfig = serde_yaml::from_str(&kubeconfig_with_proxy(None))
+    let kubeconfig: Kubeconfig = serde_saphyr::from_str(&kubeconfig_with_proxy(None))
       .expect("base kubeconfig should deserialize");
 
     let config = tokio::runtime::Runtime::new()
@@ -1181,7 +1181,7 @@ users:
     clear_https_proxy_env();
     env::set_var("Https_PrOxY", "http://env-proxy.internal:8080");
 
-    let kubeconfig: Kubeconfig = serde_yaml::from_str(&kubeconfig_with_proxy(None))
+    let kubeconfig: Kubeconfig = serde_saphyr::from_str(&kubeconfig_with_proxy(None))
       .expect("base kubeconfig should deserialize");
 
     let config = tokio::runtime::Runtime::new()
@@ -1207,7 +1207,7 @@ users:
     clear_https_proxy_env();
     env::set_var("HTTPS_PROXY", "http://env-proxy.internal:8080");
 
-    let kubeconfig: Kubeconfig = serde_yaml::from_str(&kubeconfig_with_proxy(Some(
+    let kubeconfig: Kubeconfig = serde_saphyr::from_str(&kubeconfig_with_proxy(Some(
       "http://cluster-proxy.internal:8443",
     )))
     .expect("proxy kubeconfig should deserialize");
@@ -1232,7 +1232,7 @@ users:
     let _proxy_env = ProxyEnvGuard::capture();
     clear_https_proxy_env();
 
-    let kubeconfig: Kubeconfig = serde_yaml::from_str(&kubeconfig_with_proxy(Some(
+    let kubeconfig: Kubeconfig = serde_saphyr::from_str(&kubeconfig_with_proxy(Some(
       "http://cluster-proxy.internal:8443",
     )))
     .expect("proxy kubeconfig should deserialize");


### PR DESCRIPTION
Update the kubernetes dependencies. kube-rs changed the yaml library to serde_saphyr, so this MR also includes it.

As a minor user facing change the configs are affected by the norway problem, i.e. the abbreviations for booleans (n, y, t, f) need to be quoted (noted in the changelog)